### PR TITLE
Send logs in JSON format

### DIFF
--- a/core/src/plc_app/plc_main.c
+++ b/core/src/plc_app/plc_main.c
@@ -21,6 +21,7 @@
 extern PLCState plc_state;
 volatile sig_atomic_t keep_running = 1;
 extern plc_timing_stats_t plc_timing_stats;
+extern bool print_logs;
 
 void handle_sigint(int sig) 
 {
@@ -65,8 +66,19 @@ void *print_stats_thread(void *arg)
     return NULL;
 }
 
-int main() 
+int main(int argc, char *argv[])
 {
+    // Check for --print-logs argument
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "--print-logs") == 0)
+        {
+            print_logs = true;
+            break;
+        }
+    }
+
+    // Initialize logging system
     log_set_level(LOG_LEVEL_DEBUG);
     
     if (log_init(LOG_SOCKET_PATH) < 0)

--- a/core/src/plc_app/plcapp_manager.c
+++ b/core/src/plc_app/plcapp_manager.c
@@ -51,7 +51,7 @@ bool plugin_manager_load(PluginManager *pm)
     pm->handle = dlopen(pm->so_path, RTLD_NOW);
     if (!pm->handle) 
     {
-        log_error("Failed to load plugin %s: %s\n", pm->so_path, dlerror());
+        log_error("Failed to load plugin %s: %s", pm->so_path, dlerror());
         return false;
     }
     return true;

--- a/core/src/plc_app/plcapp_manager.c
+++ b/core/src/plc_app/plcapp_manager.c
@@ -49,7 +49,7 @@ bool plugin_manager_load(PluginManager *pm)
     pm->handle = dlopen(pm->so_path, RTLD_NOW);
     if (!pm->handle) 
     {
-        fprintf(stderr, "Failed to load plugin %s: %s\n", pm->so_path, dlerror());
+        log_error("Failed to load plugin %s: %s\n", pm->so_path, dlerror());
         return false;
     }
     return true;
@@ -66,7 +66,7 @@ void *plugin_manager_get_symbol(PluginManager *pm, const char *symbol_name)
     char *err = dlerror();
     if (err) 
     {
-        fprintf(stderr, "dlsym error: %s\n", err);
+        log_error("dlsym error: %s", err);
         return NULL;
     }
     return sym;

--- a/core/src/plc_app/plcapp_manager.c
+++ b/core/src/plc_app/plcapp_manager.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "utils/log.h"
+
 struct PluginManager {
     char *so_path;
     void *handle;

--- a/core/src/plc_app/utils/log.c
+++ b/core/src/plc_app/utils/log.c
@@ -45,7 +45,7 @@ void *log_thread_management(void *arg)
             socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
             if (socket_fd < 0)
             {
-                perror("Log socket creation failed");
+                log_error("Log socket creation failed: %s", strerror(errno));
                 // Wait before retrying
                 sleep(1);
                 continue;
@@ -56,7 +56,7 @@ void *log_thread_management(void *arg)
             strncpy(addr.sun_path, unix_socket_path, sizeof(addr.sun_path) - 1);
             if (connect(socket_fd, (struct sockaddr *)&addr, sizeof(addr)) == -1)
             {
-                perror("Log socket connection failed");
+                log_error("Log socket connection failed: %s", strerror(errno));
                 close(socket_fd);
                 socket_fd = -1;
             }

--- a/core/src/plc_app/utils/utils.c
+++ b/core/src/plc_app/utils/utils.c
@@ -50,6 +50,6 @@ void set_realtime_priority(void)
     } 
     else 
     {
-        log_info("Scheduler set to SCHED_FIFO, priority %d\n", param.sched_priority);
+        log_info("Scheduler set to SCHED_FIFO, priority %d", param.sched_priority);
     }
 }

--- a/core/src/plc_app/utils/utils.c
+++ b/core/src/plc_app/utils/utils.c
@@ -46,10 +46,10 @@ void set_realtime_priority(void)
 
     if (sched_setscheduler(0, SCHED_FIFO, &param) != 0) 
     {
-        fprintf(stderr, "sched_setscheduler failed: %s\n", strerror(errno));
+        log_error("sched_setscheduler failed: %s", strerror(errno));
     } 
     else 
     {
-        printf("Scheduler set to SCHED_FIFO, priority %d\n", param.sched_priority);
+        log_info("Scheduler set to SCHED_FIFO, priority %d\n", param.sched_priority);
     }
 }

--- a/core/src/plc_app/utils/watchdog.c
+++ b/core/src/plc_app/utils/watchdog.c
@@ -30,7 +30,7 @@ void *watchdog_thread(void *arg)
         long now = atomic_load(&plc_heartbeat);
         if (now == last) 
         {
-            fprintf(stderr, "[Watchdog] No heartbeat! PLC unresponsive.\n");
+            fprintf(stderr, "[Watchdog] No heartbeat! PLC unresponsive.\n"); // Use stderr to ensure visibility and avoid lockups in log system
             exit(EXIT_FAILURE);
         }
 


### PR DESCRIPTION
This pull request introduces improvements to the logging system and refactors error and info reporting to use a consistent logging interface. The most significant changes are the JSON format for logs sent through UNIX socket, and the addition of a buffered logging mechanism that ensures log messages are not lost if the log socket is temporarily unavailable. The pull request also adds a command-line option to enable printing logs to stdout, and updates several components to use the new logging functions.

**Logging system enhancements:**

* Added a circular buffer in `log.c` to store unsent log messages, ensuring logs are not lost when the log socket is disconnected. Buffered messages are sent when the connection is restored. [[1]](diffhunk://#diff-af1a7a7eb65238d7289251917793fcf27d3265467de6850b33126846fd064945R17-R34) [[2]](diffhunk://#diff-af1a7a7eb65238d7289251917793fcf27d3265467de6850b33126846fd064945R75-R99) [[3]](diffhunk://#diff-af1a7a7eb65238d7289251917793fcf27d3265467de6850b33126846fd064945L114-R222)
* Introduced the `--print-logs` command-line argument in `plc_main.c` to enable printing logs to stdout, and updated the logging system to support this option. [[1]](diffhunk://#diff-b02fd26b5cc9fe6578e934e54acae551eefbfa5649f2fb8b8c0d9ecffcf798c1R24) [[2]](diffhunk://#diff-b02fd26b5cc9fe6578e934e54acae551eefbfa5649f2fb8b8c0d9ecffcf798c1L68-R81) [[3]](diffhunk://#diff-af1a7a7eb65238d7289251917793fcf27d3265467de6850b33126846fd064945L114-R222)

**Consistent logging interface:**

* Replaced direct `fprintf`/`perror` error reporting in `plcapp_manager.c` and `utils.c` with calls to `log_error` and `log_info` for improved consistency and integration with the logging system. [[1]](diffhunk://#diff-fd44bcff4ba9b84c3df973062ab80583b6b2a4bc552b38e4d758fd92710b2043L52-R54) [[2]](diffhunk://#diff-fd44bcff4ba9b84c3df973062ab80583b6b2a4bc552b38e4d758fd92710b2043L69-R71) [[3]](diffhunk://#diff-3669521805c016b1e62888f70202c74c45b8e586131348c04e801d9f3c3557f4L49-R53) [[4]](diffhunk://#diff-af1a7a7eb65238d7289251917793fcf27d3265467de6850b33126846fd064945L39-R48) [[5]](diffhunk://#diff-af1a7a7eb65238d7289251917793fcf27d3265467de6850b33126846fd064945L50-R59)

**Other changes:**

* Included the `log.h` header in `plcapp_manager.c` to enable use of the logging functions.
* Maintained direct `fprintf` for watchdog failure in `watchdog.c` to avoid possible lockups in the logging system during critical failures.