### PR TITLE
Rtop 91 integrate debugger on runtime v4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: pylint
         # args: [--fail-on=F,E]
         args: [
-            "--disable=C0114,C0411,C0115,C0116,C0412,E0401,W0718,R1702,R0911,R0912,R0915,R1705,W0404,W0603,W0613",
+            "--disable=C0114,C0411,C0115,C0116,C0412,E0401,W0718,R1702,R0911,R0912,R0915,R1705,W0404,W0603,W0613,W0511",
           ] # example: disable missing-docstring
         additional_dependencies:
           [flask, flask-sqlalchemy, flask_jwt_extended, werkzeug]
@@ -26,10 +26,10 @@ repos:
         args: ["--fix"]
       - id: ruff-format
         args: []
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
-    hooks:
-      - id: mypy
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v1.17.1
+  #   hooks:
+  #     - id: mypy
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v21.1.0 # Let autoupdate find the latest
     hooks:

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(plc_main
     ${CMAKE_SOURCE_DIR}/core/src/drivers/plugin_driver.c
     ${CMAKE_SOURCE_DIR}/core/src/drivers/plugin_config.c
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/unix_socket.c
+    ${CMAKE_SOURCE_DIR}/core/src/plc_app/debug_handler.c
 )
 
 # Link against shared library

--- a/core/src/plc_app/debug_handler.c
+++ b/core/src/plc_app/debug_handler.c
@@ -1,11 +1,268 @@
 #include "debug_handler.h"
+#include "image_tables.h"
 #include "utils/log.h"
+#include "utils/utils.h"
+#include <string.h>
+
+#define MAX_DEBUG_FRAME 4096
+
+#define MB_FC_DEBUG_INFO 0x41
+#define MB_FC_DEBUG_SET 0x42
+#define MB_FC_DEBUG_GET 0x43
+#define MB_FC_DEBUG_GET_LIST 0x44
+#define MB_FC_DEBUG_GET_MD5 0x45
+
+#define MB_DEBUG_SUCCESS 0x7E
+#define MB_DEBUG_ERROR_OUT_OF_BOUNDS 0x81
+#define MB_DEBUG_ERROR_OUT_OF_MEMORY 0x82
+
+#define SAME_ENDIANNESS 0
+#define REVERSE_ENDIANNESS 1
+
+#define VARIDX_SIZE 256
+
+static void debugInfo(uint8_t *frame, size_t *frame_len)
+{
+    uint16_t variableCount = ext_get_var_count();
+    *frame_len             = 3;
+    frame[0]               = MB_FC_DEBUG_INFO;
+    frame[1]               = (uint8_t)(variableCount >> 8);
+    frame[2]               = (uint8_t)(variableCount & 0xFF);
+}
+
+static void debugSetTrace(uint8_t *frame, size_t *frame_len, uint16_t varidx, uint8_t flag,
+                          uint16_t len, void *value)
+{
+    uint16_t variableCount = ext_get_var_count();
+    if (varidx >= variableCount || len > (MAX_DEBUG_FRAME - 7))
+    {
+        *frame_len = 2;
+        frame[0]   = MB_FC_DEBUG_SET;
+        frame[1]   = MB_DEBUG_ERROR_OUT_OF_BOUNDS;
+        return;
+    }
+
+    ext_set_trace((size_t)varidx, (bool)flag, value);
+
+    *frame_len = 2;
+    frame[0]   = MB_FC_DEBUG_SET;
+    frame[1]   = MB_DEBUG_SUCCESS;
+}
+
+static void debugGetTrace(uint8_t *frame, size_t *frame_len, uint16_t startidx, uint16_t endidx)
+{
+    uint16_t variableCount = ext_get_var_count();
+    if (startidx >= variableCount || endidx >= variableCount || startidx > endidx)
+    {
+        *frame_len = 2;
+        frame[0]   = MB_FC_DEBUG_GET;
+        frame[1]   = MB_DEBUG_ERROR_OUT_OF_BOUNDS;
+        return;
+    }
+
+    uint16_t lastVarIdx  = startidx;
+    size_t responseSize  = 0;
+    uint8_t *responsePtr = &(frame[10]);
+
+    for (uint16_t varidx = startidx; varidx <= endidx; varidx++)
+    {
+        size_t varSize = ext_get_var_size(varidx);
+        if ((responseSize + 10) + varSize <= MAX_DEBUG_FRAME)
+        {
+            void *varAddr = ext_get_var_addr(varidx);
+
+            memcpy(responsePtr, varAddr, varSize);
+
+            responsePtr += varSize;
+            responseSize += varSize;
+
+            lastVarIdx = varidx;
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    *frame_len = 10 + responseSize;
+    frame[0]   = MB_FC_DEBUG_GET;
+    frame[1]   = MB_DEBUG_SUCCESS;
+    frame[2]   = (uint8_t)(lastVarIdx >> 8);
+    frame[3]   = (uint8_t)(lastVarIdx & 0xFF);
+    frame[4]   = (uint8_t)((tick__ >> 24) & 0xFF);
+    frame[5]   = (uint8_t)((tick__ >> 16) & 0xFF);
+    frame[6]   = (uint8_t)((tick__ >> 8) & 0xFF);
+    frame[7]   = (uint8_t)(tick__ & 0xFF);
+    frame[8]   = (uint8_t)(responseSize >> 8);
+    frame[9]   = (uint8_t)(responseSize & 0xFF);
+}
+
+static void debugGetTraceList(uint8_t *frame, size_t *frame_len, uint16_t numIndexes,
+                              uint8_t *indexArray)
+{
+    uint16_t response_idx  = 10;
+    uint16_t responseSize  = 0;
+    uint16_t lastVarIdx    = 0;
+    uint16_t variableCount = ext_get_var_count();
+
+    uint16_t varidx_array[VARIDX_SIZE];
+
+    if (numIndexes > VARIDX_SIZE)
+    {
+        *frame_len = 2;
+        frame[0]   = MB_FC_DEBUG_GET_LIST;
+        frame[1]   = MB_DEBUG_ERROR_OUT_OF_MEMORY;
+        return;
+    }
+
+    for (uint16_t i = 0; i < numIndexes; i++)
+    {
+        varidx_array[i] = (uint16_t)indexArray[i * 2] << 8 | indexArray[i * 2 + 1];
+    }
+
+    for (uint16_t i = 0; i < numIndexes; i++)
+    {
+        if (varidx_array[i] >= variableCount)
+        {
+            *frame_len = 2;
+            frame[0]   = MB_FC_DEBUG_GET_LIST;
+            frame[1]   = MB_DEBUG_ERROR_OUT_OF_BOUNDS;
+            return;
+        }
+
+        size_t varSize = ext_get_var_size(varidx_array[i]);
+
+        if (response_idx + varSize <= MAX_DEBUG_FRAME)
+        {
+            void *varAddr = ext_get_var_addr(varidx_array[i]);
+            memcpy(&frame[response_idx], varAddr, varSize);
+            response_idx += varSize;
+            responseSize += varSize;
+
+            lastVarIdx = varidx_array[i];
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    *frame_len = response_idx;
+    frame[0]   = MB_FC_DEBUG_GET_LIST;
+    frame[1]   = MB_DEBUG_SUCCESS;
+    frame[2]   = (uint8_t)(lastVarIdx >> 8);
+    frame[3]   = (uint8_t)(lastVarIdx & 0xFF);
+    frame[4]   = (uint8_t)((tick__ >> 24) & 0xFF);
+    frame[5]   = (uint8_t)((tick__ >> 16) & 0xFF);
+    frame[6]   = (uint8_t)((tick__ >> 8) & 0xFF);
+    frame[7]   = (uint8_t)(tick__ & 0xFF);
+    frame[8]   = (uint8_t)(responseSize >> 8);
+    frame[9]   = (uint8_t)(responseSize & 0xFF);
+}
+
+static void debugGetMd5(uint8_t *frame, size_t *frame_len, void *endianness)
+{
+    uint16_t endian_check = 0;
+    memcpy(&endian_check, endianness, 2);
+    if (endian_check == 0xDEAD)
+    {
+        ext_set_endianness(SAME_ENDIANNESS);
+    }
+    else if (endian_check == 0xADDE)
+    {
+        ext_set_endianness(REVERSE_ENDIANNESS);
+    }
+    else
+    {
+        *frame_len = 2;
+        frame[0]   = MB_FC_DEBUG_GET_MD5;
+        frame[1]   = MB_DEBUG_ERROR_OUT_OF_BOUNDS;
+        return;
+    }
+
+    frame[0] = MB_FC_DEBUG_GET_MD5;
+    frame[1] = MB_DEBUG_SUCCESS;
+
+    const char md5[] = "0000000000000000";
+    int md5_len      = 0;
+    for (md5_len = 0; md5[md5_len] != '\0'; md5_len++)
+    {
+        frame[md5_len + 2] = md5[md5_len];
+    }
+
+    *frame_len = md5_len + 2;
+}
 
 size_t process_debug_data(uint8_t *data, size_t length)
 {
-    // Process the debug data as needed
-    // This is a placeholder implementation
-    data[0] = 0;
-    log_info("Processing debug data of length %zu", length);
-    return length;
+    if (length < 1)
+    {
+        log_error("Debug data too short");
+        return 0;
+    }
+
+    uint8_t fcode          = data[0];
+    uint16_t field1        = 0;
+    uint16_t field2        = 0;
+    uint8_t flag           = 0;
+    uint16_t len           = 0;
+    void *value            = NULL;
+    void *endianness_check = NULL;
+
+    if (length >= 3)
+    {
+        field1 = (uint16_t)data[1] << 8 | (uint16_t)data[2];
+    }
+    if (length >= 5)
+    {
+        field2 = (uint16_t)data[3] << 8 | (uint16_t)data[4];
+    }
+    if (length >= 4)
+    {
+        flag = data[3];
+    }
+    if (length >= 6)
+    {
+        len = (uint16_t)data[4] << 8 | (uint16_t)data[5];
+    }
+    if (length >= 7)
+    {
+        value = &data[6];
+    }
+    if (length >= 2)
+    {
+        endianness_check = &data[1];
+    }
+
+    size_t response_len = 0;
+
+    switch (fcode)
+    {
+    case MB_FC_DEBUG_INFO:
+        debugInfo(data, &response_len);
+        break;
+
+    case MB_FC_DEBUG_GET:
+        debugGetTrace(data, &response_len, field1, field2);
+        break;
+
+    case MB_FC_DEBUG_GET_LIST:
+        debugGetTraceList(data, &response_len, field1, &data[3]);
+        break;
+
+    case MB_FC_DEBUG_SET:
+        debugSetTrace(data, &response_len, field1, flag, len, value);
+        break;
+
+    case MB_FC_DEBUG_GET_MD5:
+        debugGetMd5(data, &response_len, endianness_check);
+        break;
+
+    default:
+        log_error("Unknown debug function code: 0x%02X", fcode);
+        return 0;
+    }
+
+    log_debug("Processed debug function 0x%02X, response length: %zu", fcode, response_len);
+    return response_len;
 }

--- a/core/src/plc_app/debug_handler.c
+++ b/core/src/plc_app/debug_handler.c
@@ -1,0 +1,9 @@
+#include "debug_handler.h"
+#include "utils/log.h"
+
+void process_debug_data(uint8_t *data, size_t length)
+{
+    // Process the debug data as needed
+    // This is a placeholder implementation
+    log_info("Processing debug data of length %zu", length);
+}

--- a/core/src/plc_app/debug_handler.c
+++ b/core/src/plc_app/debug_handler.c
@@ -5,6 +5,7 @@ size_t process_debug_data(uint8_t *data, size_t length)
 {
     // Process the debug data as needed
     // This is a placeholder implementation
+    data[0] = 0;
     log_info("Processing debug data of length %zu", length);
     return length;
 }

--- a/core/src/plc_app/debug_handler.c
+++ b/core/src/plc_app/debug_handler.c
@@ -1,9 +1,10 @@
 #include "debug_handler.h"
 #include "utils/log.h"
 
-void process_debug_data(uint8_t *data, size_t length)
+size_t process_debug_data(uint8_t *data, size_t length)
 {
     // Process the debug data as needed
     // This is a placeholder implementation
     log_info("Processing debug data of length %zu", length);
+    return length;
 }

--- a/core/src/plc_app/debug_handler.h
+++ b/core/src/plc_app/debug_handler.h
@@ -1,0 +1,10 @@
+#ifndef DEBUG_HANDLER_H
+#define DEBUG_HANDLER_H
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void process_debug_data(uint8_t *data, size_t length);
+
+#endif // DEBUG_HANDLER_H

--- a/core/src/plc_app/debug_handler.h
+++ b/core/src/plc_app/debug_handler.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 size_t process_debug_data(uint8_t *data, size_t length);
 

--- a/core/src/plc_app/debug_handler.h
+++ b/core/src/plc_app/debug_handler.h
@@ -5,6 +5,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void process_debug_data(uint8_t *data, size_t length);
+size_t process_debug_data(uint8_t *data, size_t length);
 
 #endif // DEBUG_HANDLER_H

--- a/core/src/plc_app/image_tables.c
+++ b/core/src/plc_app/image_tables.c
@@ -44,6 +44,15 @@ void (*ext_setBufferPointers)(
     IEC_UINT *int_memory[BUFFER_SIZE], IEC_UDINT *dint_memory[BUFFER_SIZE],
     IEC_ULINT *lint_memory[BUFFER_SIZE]);
 
+
+// Debug
+void (*ext_set_endianness)(uint8_t value);
+uint16_t (*ext_get_var_count)(void);
+size_t (*ext_get_var_size)(size_t idx);
+void *(*ext_get_var_addr)(size_t idx);
+void (*ext_set_trace)(size_t idx, bool forced, void *val);
+
+
 int symbols_init(PluginManager *pm) 
 {
     // Get pointer to external functions
@@ -65,9 +74,26 @@ int symbols_init(PluginManager *pm)
     *(void **)(&ext_common_ticktime__) =
         plugin_manager_get_func(pm, void (*)(unsigned long), "common_ticktime__");
 
+    *(void **)(&ext_set_endianness) =
+        plugin_manager_get_func(pm, void (*)(unsigned long), "set_endianness");
+
+    *(void **)(&ext_get_var_count) =
+        plugin_manager_get_func(pm, uint16_t (*)(uint16_t), "get_var_count");
+
+    *(void **)(&ext_get_var_size) =
+        plugin_manager_get_func(pm, size_t (*)(size_t), "get_var_size");
+
+    *(void **)(&ext_get_var_addr) =
+        plugin_manager_get_func(pm, void *(*)(unsigned long), "get_var_addr");
+
+    *(void **)(&ext_set_trace) =
+        plugin_manager_get_func(pm, void (*)(unsigned long), "set_trace");
+
     // Check if all symbols were loaded successfully
     if (!ext_config_run__ || !ext_config_init__ || !ext_glueVars ||
-        !ext_updateTime || !ext_setBufferPointers || !ext_common_ticktime__) 
+        !ext_updateTime || !ext_setBufferPointers || !ext_common_ticktime__ ||
+        !ext_set_endianness || !ext_get_var_count || !ext_get_var_size ||
+        !ext_get_var_addr || !ext_set_trace) 
     {
         log_error("Failed to load all symbols");
         return -1;

--- a/core/src/plc_app/image_tables.h
+++ b/core/src/plc_app/image_tables.h
@@ -66,6 +66,15 @@ extern void (*ext_glueVars)(void);
 extern void (*ext_updateTime)(void);
 
 /**
+ * @brief Debug functions
+ */
+extern void (*ext_set_endianness)(uint8_t value);
+extern uint16_t (*ext_get_var_count)(void);
+extern size_t (*ext_get_var_size)(size_t idx);
+extern void *(*ext_get_var_addr)(size_t idx);
+extern void (*ext_set_trace)(size_t idx, bool forced, void *val);
+
+/**
  * @brief Initialize symbols for the plugin manager
  *
  * @param[in]  pm  The plugin manager to initialize symbols for

--- a/core/src/plc_app/unix_socket.c
+++ b/core/src/plc_app/unix_socket.c
@@ -1,19 +1,19 @@
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
-#include <pthread.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <stdatomic.h>
-#include <signal.h>
 
+#include "debug_handler.h"
+#include "plc_state_manager.h"
 #include "unix_socket.h"
 #include "utils/log.h"
 #include "utils/utils.h"
-#include "plc_state_manager.h"
-#include "debug_handler.h"
 
 extern volatile sig_atomic_t keep_running;
 extern PLCState plc_state;
@@ -23,14 +23,14 @@ static ssize_t read_line(int fd, char *buffer, size_t max_length)
 {
     size_t total_read = 0;
     char ch;
-    while (total_read < max_length - 1) 
+    while (total_read < max_length - 1)
     {
         ssize_t bytes_read = read(fd, &ch, 1);
-        if (bytes_read <= 0) 
+        if (bytes_read <= 0)
         {
             return bytes_read; // error or connection closed
         }
-        if (ch == '\n') 
+        if (ch == '\n')
         {
             break; // end of line
         }
@@ -94,11 +94,11 @@ void handle_unix_socket_commands(const char *command, char *response, size_t res
             log_error("Received START command but PLC is already RUNNING");
         }
     }
-    else if (strcmp(command, "DEBUG:") == 0)
+    else if (strncmp(command, "DEBUG:", 6) == 0)
     {
         log_debug("Received DEBUG command");
         uint8_t debug_data[4096] = {0};
-        size_t data_length = parse_hex_string(&command[6], debug_data);
+        size_t data_length       = parse_hex_string(&command[6], debug_data);
         if (data_length > 0)
         {
             data_length = process_debug_data(debug_data, data_length);
@@ -115,7 +115,7 @@ void handle_unix_socket_commands(const char *command, char *response, size_t res
         {
             strncpy(response, "DEBUG:ERROR_PARSING\n", response_size);
         }
-    }   
+    }
     else
     {
         log_error("Unknown command received: %s", command);
@@ -126,21 +126,21 @@ void handle_unix_socket_commands(const char *command, char *response, size_t res
     response[response_size - 1] = '\0';
 }
 
-void *unix_socket_thread(void *arg) 
+void *unix_socket_thread(void *arg)
 {
     (void)arg;
     int *server_fd_pt = (int *)arg;
     int client_fd;
     char command_buffer[COMMAND_BUFFER_SIZE];
 
-    if (server_fd_pt == NULL) 
+    if (server_fd_pt == NULL)
     {
         log_error("Server file descriptor is NULL");
         return NULL;
     }
-    
+
     int server_fd = *server_fd_pt;
-    if (server_fd < 0) 
+    if (server_fd < 0)
     {
         log_error("Failed to set up UNIX socket");
         return NULL;
@@ -149,14 +149,14 @@ void *unix_socket_thread(void *arg)
     while (keep_running)
     {
         client_fd = accept(server_fd, NULL, NULL);
-        if (client_fd < 0) 
+        if (client_fd < 0)
         {
-            if (errno == EINTR) 
+            if (errno == EINTR)
             {
                 continue; // Interrupted by signal, retry
             }
             log_error("Unix socket accept failed: %s", strerror(errno));
-            
+
             // Retry after a short delay
             sleep(1);
             continue;
@@ -167,14 +167,14 @@ void *unix_socket_thread(void *arg)
         while (keep_running)
         {
             ssize_t bytes_read = read_line(client_fd, command_buffer, COMMAND_BUFFER_SIZE);
-            if (bytes_read > 0) 
+            if (bytes_read > 0)
             {
                 log_debug("Received command: %s", command_buffer);
 
                 // Handle the command
                 char response[MAX_RESPONSE_SIZE] = {0};
                 handle_unix_socket_commands(command_buffer, response, MAX_RESPONSE_SIZE);
-                if (strlen(response) > 0) 
+                if (strlen(response) > 0)
                 {
                     ssize_t bytes_written = write(client_fd, response, strlen(response));
                     if (bytes_written <= 0)
@@ -187,8 +187,8 @@ void *unix_socket_thread(void *arg)
             {
                 log_info("Unix socket client disconnected");
                 break;
-            } 
-            else 
+            }
+            else
             {
                 log_error("Unix socket read failed: %s", strerror(errno));
                 break;
@@ -203,7 +203,7 @@ void *unix_socket_thread(void *arg)
 
 void close_unix_socket(int server_fd)
 {
-    if (server_fd >= 0) 
+    if (server_fd >= 0)
     {
         close(server_fd);
         unlink(SOCKET_PATH);
@@ -220,7 +220,7 @@ int setup_unix_socket()
     unlink(SOCKET_PATH);
 
     // Create socket
-    if ((server_fd = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) 
+    if ((server_fd = socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
     {
         log_error("Socket creation failed: %s", strerror(errno));
         return -1;
@@ -232,7 +232,7 @@ int setup_unix_socket()
     strncpy(address.sun_path, SOCKET_PATH, sizeof(address.sun_path) - 1);
 
     // Bind socket to the address
-    if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0) 
+    if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0)
     {
         log_error("Socket bind failed: %s", strerror(errno));
         close(server_fd);
@@ -240,7 +240,7 @@ int setup_unix_socket()
     }
 
     // Listen for incoming connections
-    if (listen(server_fd, MAX_CLIENTS) < 0) 
+    if (listen(server_fd, MAX_CLIENTS) < 0)
     {
         log_error("Socket listen failed: %s", strerror(errno));
         close(server_fd);
@@ -248,12 +248,12 @@ int setup_unix_socket()
     }
 
     log_info("UNIX socket server setup at %s", SOCKET_PATH);
-    
+
     // Create a thread to handle socket commands
     pthread_t socket_thread;
     int *fd_ptr = malloc(sizeof(int));
-    *fd_ptr = server_fd;
-    if (pthread_create(&socket_thread, NULL, unix_socket_thread, fd_ptr) != 0) 
+    *fd_ptr     = server_fd;
+    if (pthread_create(&socket_thread, NULL, unix_socket_thread, fd_ptr) != 0)
     {
         log_error("Failed to create UNIX socket thread: %s", strerror(errno));
         close(server_fd);

--- a/core/src/plc_app/unix_socket.c
+++ b/core/src/plc_app/unix_socket.c
@@ -93,6 +93,28 @@ void handle_unix_socket_commands(const char *command, char *response, size_t res
             log_error("Received START command but PLC is already RUNNING");
         }
     }
+    else if (strcmp(command, "DEBUG:") == 0)
+    {
+        log_debug("Received DEBUG command");
+        uint8_t debug_data[4096] = {0};
+        size_t data_length = parse_hex_string(&command[6], debug_data);
+        if (data_length > 0)
+        {
+            data_length = process_debug_data(debug_data, data_length);
+            if (data_length > 0)
+            {
+                bytes_to_hex_string(debug_data, data_length, response, response_size, "DEBUG:");
+            }
+            else
+            {
+                strncpy(response, "DEBUG:ERROR_PROCESSING\n", response_size);
+            }
+        }
+        else
+        {
+            strncpy(response, "DEBUG:ERROR_PARSING\n", response_size);
+        }
+    }   
     else
     {
         log_error("Unknown command received: %s", command);

--- a/core/src/plc_app/unix_socket.c
+++ b/core/src/plc_app/unix_socket.c
@@ -13,6 +13,7 @@
 #include "utils/log.h"
 #include "utils/utils.h"
 #include "plc_state_manager.h"
+#include "debug_handler.h"
 
 extern volatile sig_atomic_t keep_running;
 extern PLCState plc_state;

--- a/core/src/plc_app/unix_socket.h
+++ b/core/src/plc_app/unix_socket.h
@@ -2,8 +2,8 @@
 #define UNIX_SOCKET_H
 
 #define SOCKET_PATH "/run/runtime/plc_runtime.socket"
-#define COMMAND_BUFFER_SIZE 1024
-#define MAX_RESPONSE_SIZE 1024
+#define COMMAND_BUFFER_SIZE 8192
+#define MAX_RESPONSE_SIZE 8192
 #define MAX_CLIENTS 1
 
 int setup_unix_socket();

--- a/core/src/plc_app/utils/utils.c
+++ b/core/src/plc_app/utils/utils.c
@@ -53,3 +53,97 @@ void set_realtime_priority(void)
         log_info("Scheduler set to SCHED_FIFO, priority %d", param.sched_priority);
     }
 }
+
+size_t parse_hex_string(const char *hex_string, uint8_t *data)
+{
+    size_t count = 0;
+    const char *ptr = hex_string;
+
+    while (*ptr != '\0')
+    {
+        // Skip leading spaces
+        while (*ptr == ' ')
+        {
+            ptr++;
+        }
+
+        if (*ptr == '\0')
+        {
+            break;
+        }
+
+        // Read two hex digits
+        unsigned int value;
+        int scanned = sscanf(ptr, "%2x", &value);
+        if (scanned != 1)
+        {
+            break;
+        }
+
+        data[count++] = (uint8_t)value;
+
+        // Move past the parsed value (2 hex chars)
+        while (*ptr != '\0' && *ptr != ' ')
+        {
+            ptr++;
+        }
+    }
+
+    return count;
+}
+
+void bytes_to_hex_string(const uint8_t *bytes, size_t len, char *out_str, size_t out_size, const char *prepend)
+{
+    size_t pos = 0;
+
+    // Add prepend string first, if provided
+    if (prepend != NULL)
+    {
+        size_t prepend_len = strlen(prepend);
+        if (prepend_len >= out_size)
+        {
+            // Not enough space even for prepend
+            if (out_size > 0)
+            {
+                out_str[0] = '\0';
+            }
+            return;
+        }
+        strcpy(out_str, prepend);
+        pos = prepend_len;
+    }
+
+    for (size_t i = 0; i < len; i++)
+    {
+        // Each byte needs up to 3 chars: "xx " + null terminator at the end
+        int written = snprintf(out_str + pos, out_size - pos, "%02x", bytes[i]);
+        if (written < 0 || (size_t)written >= out_size - pos)
+        {
+            // Stop if buffer is full or error
+            break; 
+        }
+
+        pos += written;
+
+        if (i < len - 1)
+        {
+            if (pos + 1 >= out_size)
+            {
+                break;
+            }
+            out_str[pos++] = ' ';
+            out_str[pos] = '\0';
+        }
+    }
+
+    // Ensure null termination
+    if (pos < out_size)
+    {
+        out_str[pos] = '\0';
+    }
+    else
+    {
+        out_str[out_size - 1] = '\0';
+    }
+}
+

--- a/core/src/plc_app/utils/utils.h
+++ b/core/src/plc_app/utils/utils.h
@@ -4,6 +4,7 @@
 #include <dlfcn.h>
 #include <sched.h>
 #include <time.h>
+#include <stdint.h>
 
 #include "log.h"
 

--- a/core/src/plc_app/utils/utils.h
+++ b/core/src/plc_app/utils/utils.h
@@ -40,4 +40,24 @@ void timespec_diff(struct timespec *a, struct timespec *b,
  */
 void set_realtime_priority(void);
 
+/**
+ * @brief Parse a hex string into a byte array
+ *
+ * @param hex_string The hex string to parse
+ * @param data The byte array to store the result
+ * @return The number of bytes parsed
+ */
+size_t parse_hex_string(const char *hex_string, uint8_t *data);
+
+/**
+ * @brief Convert a byte array to a hex string
+ *
+ * @param bytes The byte array to convert
+ * @param len The length of the byte array
+ * @param out_str The string to store the result
+ * @param out_size The size of the output string buffer
+ * @param prepend An optional string to prepend to the output (can be NULL)
+ */
+void bytes_to_hex_string(const uint8_t *bytes, size_t len, char *out_str, size_t out_size, const char *prepend);
+
 #endif // UTILS_H

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask
 Flask-Login
 Flask-JWT-Extended
 flask_sqlalchemy
+Flask-SocketIO
 PyJWT
 python-dotenv
 pytest

--- a/webserver/DEBUG_WEBSOCKET.md
+++ b/webserver/DEBUG_WEBSOCKET.md
@@ -1,0 +1,192 @@
+# WebSocket Debug Protocol
+
+## Overview
+
+The OpenPLC Runtime v4 provides a secure WebSocket endpoint for debugger communication over HTTPS. This allows the OpenPLC Editor to maintain a persistent, authenticated connection for real-time variable polling without the overhead of repeated TLS handshakes.
+
+## Connection
+
+### Endpoint
+```
+wss://<runtime-host>:8443/api/debug
+```
+
+### Authentication
+The WebSocket connection requires JWT authentication via query parameter:
+```
+wss://localhost:8443/api/debug?token=<JWT_ACCESS_TOKEN>
+```
+
+The JWT token is obtained through the standard REST API login endpoint:
+```bash
+POST https://localhost:8443/api/login
+Content-Type: application/json
+
+{
+  "username": "admin",
+  "password": "password"
+}
+```
+
+Response:
+```json
+{
+  "access_token": "eyJhbGc..."
+}
+```
+
+## Protocol
+
+### Connection Events
+
+#### `connect`
+Emitted by server when connection is successfully established and authenticated.
+
+**Server Response:**
+```json
+{
+  "status": "ok"
+}
+```
+
+#### `disconnect`
+Connection closed (either by client or server).
+
+### Debug Communication
+
+#### `debug_command` (Client → Server)
+Send debug command to the runtime.
+
+**Request:**
+```json
+{
+  "command": "41 DE AD 00 00"
+}
+```
+
+Where `command` is a hex string representing the debug command bytes (same format as Arduino/Modbus implementation).
+
+**Response Event:** `debug_response`
+
+#### `debug_response` (Server → Client)
+Response to debug command.
+
+**Success Response:**
+```json
+{
+  "success": true,
+  "data": "7E 12 34 56 78"
+}
+```
+
+**Error Response:**
+```json
+{
+  "success": false,
+  "error": "Error message"
+}
+```
+
+## Debug Command Format
+
+The debug commands follow the same protocol as the Arduino/Modbus implementation:
+
+### Function Codes
+- `0x41` - DEBUG_INFO: Get debug information
+- `0x42` - DEBUG_SET: Set trace variable
+- `0x43` - DEBUG_GET: Get trace data
+- `0x44` - DEBUG_GET_LIST: Get list of variable values
+- `0x45` - DEBUG_GET_MD5: Get MD5 hash
+
+### Example: Get MD5 Hash
+**Request:**
+```json
+{
+  "command": "45 DE AD 00 00"
+}
+```
+
+**Response (Success):**
+```json
+{
+  "success": true,
+  "data": "7E 61 62 63 64 65 66 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 00"
+}
+```
+
+### Example: Get Variables List
+**Request:**
+```json
+{
+  "command": "44 00 03 00 00 00 01 00 02"
+}
+```
+(Get 3 variables: indexes 0, 1, 2)
+
+**Response (Success):**
+```json
+{
+  "success": true,
+  "data": "7E 00 02 00 00 00 64 00 0A 01 00 01 01"
+}
+```
+
+## Client Implementation Example (JavaScript)
+
+```javascript
+import io from 'socket.io-client';
+
+// Obtain JWT token first
+const response = await fetch('https://localhost:8443/api/login', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ username: 'admin', password: 'password' })
+});
+const { access_token } = await response.json();
+
+// Connect to WebSocket with authentication
+const socket = io('wss://localhost:8443/api/debug', {
+  transports: ['websocket'],
+  query: { token: access_token },
+  rejectUnauthorized: false  // Only for self-signed certificates in development
+});
+
+socket.on('connected', (data) => {
+  console.log('Connected:', data);
+
+  // Send debug command
+  socket.emit('debug_command', {
+    command: '45 DE AD 00 00'  // Get MD5
+  });
+});
+
+socket.on('debug_response', (response) => {
+  if (response.success) {
+    console.log('Debug data:', response.data);
+  } else {
+    console.error('Debug error:', response.error);
+  }
+});
+
+socket.on('disconnect', () => {
+  console.log('Disconnected');
+});
+```
+
+## Benefits
+
+1. **Single TLS Handshake**: WebSocket connection is established once per debug session
+2. **Persistent Connection**: No reconnection overhead during variable polling
+3. **Bidirectional**: Efficient request-response pattern
+4. **Secure**: JWT authentication + HTTPS/WSS encryption
+5. **Compatible**: Uses same debug protocol format as existing Arduino/Modbus implementation
+
+## Migration Notes
+
+For OpenPLC Editor developers:
+
+1. Replace TCP socket (port 502) connection with WebSocket connection
+2. Obtain JWT token via REST API login before connecting
+3. Use same hex string command format for debug commands
+4. Parse responses in same format as Modbus implementation
+5. Connection lifetime matches debug session (connect when debug starts, disconnect when debug stops)

--- a/webserver/DEBUG_WEBSOCKET.md
+++ b/webserver/DEBUG_WEBSOCKET.md
@@ -173,6 +173,74 @@ socket.on('disconnect', () => {
 });
 ```
 
+## Client Implementation Example (Python)
+
+### Installation
+```bash
+pip3 install python-socketio[client]
+```
+
+### Test Script
+```python
+#!/usr/bin/env python3
+import socketio
+
+# Get JWT token from /api/login first
+TOKEN = "your_jwt_token_here"
+
+sio = socketio.Client(ssl_verify=False)
+
+@sio.event(namespace='/api/debug')
+def connect():
+    print("✓ Connected to WebSocket!")
+
+@sio.event(namespace='/api/debug')
+def connected(data):
+    print(f"✓ Server confirmed: {data}")
+
+@sio.event(namespace='/api/debug')
+def debug_response(data):
+    print(f"\n✓ Debug response:")
+    print(f"  Success: {data.get('success')}")
+    if data.get('success'):
+        print(f"  Data: {data.get('data')}")
+    else:
+        print(f"  Error: {data.get('error')}")
+
+@sio.event(namespace='/api/debug')
+def disconnect():
+    print("✗ Disconnected")
+
+# Connect with token in auth dict (preferred method)
+try:
+    sio.connect(
+        'https://localhost:8443',
+        auth={'token': TOKEN},
+        namespaces=['/api/debug'],
+        transports=['websocket']
+    )
+
+    # Send debug command
+    sio.emit('debug_command', {
+        'command': '41 DE AD 00 00'  # DEBUG_INFO command
+    }, namespace='/api/debug')
+
+    sio.sleep(2)  # Wait for response
+    sio.disconnect()
+
+except Exception as e:
+    print(f"Error: {e}")
+```
+
+**Note:** You can also pass the token via query string as a fallback:
+```python
+sio.connect(
+    f'https://localhost:8443?token={TOKEN}',
+    namespaces=['/api/debug'],
+    transports=['websocket']
+)
+```
+
 ## Benefits
 
 1. **Single TLS Handshake**: WebSocket connection is established once per debug session

--- a/webserver/debug_websocket.py
+++ b/webserver/debug_websocket.py
@@ -1,0 +1,145 @@
+"""
+WebSocket debug endpoint for OpenPLC Runtime v4
+
+This module provides a secure WebSocket interface for debugger communication.
+It receives debug commands in hex format, forwards them to the Unix socket,
+and returns responses through the WebSocket connection.
+"""
+
+from flask import request
+from flask_jwt_extended import decode_token
+from flask_socketio import SocketIO, disconnect, emit
+from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
+from logger import get_logger
+
+logger, _ = get_logger("debug_ws", use_buffer=True)
+
+_socketio = None  # pylint: disable=invalid-name
+_unix_client = None  # pylint: disable=invalid-name
+
+
+def init_debug_websocket(app, unix_client_instance):
+    """
+    Initialize the WebSocket server for debug communication.
+
+    Args:
+        app: Flask application instance
+        unix_client_instance: SyncUnixClient instance for communicating with C core
+    """
+    global _socketio, _unix_client
+
+    _unix_client = unix_client_instance
+
+    _socketio = SocketIO(
+        app,
+        cors_allowed_origins="*",
+        async_mode="threading",
+        logger=False,
+        engineio_logger=False,
+        ping_timeout=60,
+        ping_interval=25,
+    )
+
+    @_socketio.on("connect", namespace="/api/debug")
+    def handle_connect():
+        """Handle WebSocket connection with JWT authentication"""
+        try:
+            token = request.args.get("token")
+            if not token:
+                logger.warning("Debug WebSocket connection attempt without token")
+                disconnect()
+                return False
+
+            try:
+                decoded = decode_token(token)
+                logger.info("Debug WebSocket connected for user %s", decoded.get("sub"))
+                emit("connected", {"status": "ok"})
+                return True
+
+            except (ExpiredSignatureError, InvalidTokenError) as e:
+                logger.warning("Debug WebSocket auth failed: %s", e)
+                disconnect()
+                return False
+
+        except Exception as e:
+            logger.error("Error during debug WebSocket connection: %s", e)
+            disconnect()
+            return False
+
+    @_socketio.on("disconnect", namespace="/api/debug")
+    def handle_disconnect():
+        """Handle WebSocket disconnection"""
+        logger.info("Debug WebSocket disconnected")
+
+    @_socketio.on("debug_command", namespace="/api/debug")
+    def handle_debug_command(data):
+        """
+        Handle debug command from the client.
+
+        Expected data format:
+        {
+            'command': 'hex string of debug data (e.g., "41 00 00")'
+        }
+
+        Returns debug response in same hex format
+        """
+        try:
+            if not _unix_client or not _unix_client.is_connected():
+                logger.error("Unix socket not connected")
+                emit(
+                    "debug_response",
+                    {"success": False, "error": "Runtime not connected"},
+                )
+                return
+
+            command_hex = data.get("command", "")
+            if not command_hex:
+                logger.warning("Empty debug command received")
+                emit("debug_response", {"success": False, "error": "Empty command"})
+                return
+
+            logger.debug("Debug command received: %s", command_hex)
+
+            unix_command = f"DEBUG:{command_hex}\n"
+            _unix_client.send_message(unix_command)
+
+            response = _unix_client.recv_message(timeout=2.0)
+
+            if response is None:
+                logger.warning("No response from runtime")
+                emit(
+                    "debug_response",
+                    {"success": False, "error": "No response from runtime"},
+                )
+                return
+
+            if response.startswith("DEBUG:"):
+                response_hex = response[6:].strip()
+                logger.debug("Debug response: %s", response_hex)
+                emit("debug_response", {"success": True, "data": response_hex})
+            elif response.startswith("DEBUG:ERROR"):
+                error_msg = (
+                    response.split(":", 2)[2]
+                    if len(response.split(":")) > 2
+                    else "Unknown error"
+                )
+                logger.warning("Debug error from runtime: %s", error_msg)
+                emit("debug_response", {"success": False, "error": error_msg})
+            else:
+                logger.warning("Unexpected response format: %s", response)
+                emit(
+                    "debug_response",
+                    {"success": False, "error": "Unexpected response format"},
+                )
+
+        except Exception as e:
+            logger.error("Error processing debug command: %s", e)
+            emit("debug_response", {"success": False, "error": str(e)})
+
+    logger.info("Debug WebSocket endpoint initialized at /api/debug")
+    return _socketio
+
+
+def get_socketio():
+    """Get the SocketIO instance"""
+    return _socketio

--- a/webserver/debug_websocket.py
+++ b/webserver/debug_websocket.py
@@ -38,20 +38,8 @@ def init_debug_websocket(app, unix_client_instance):
         engineio_logger=False,
         ping_timeout=60,
         ping_interval=25,
+        allow_upgrades=False,
     )
-
-    @_socketio.on("connect")
-    def handle_root_connect():
-        """
-        Handle root namespace connections.
-        These typically occur during client disconnect polling fallback.
-        We silently accept but don't provide any functionality.
-        """
-        return True
-
-    @_socketio.on("disconnect")
-    def handle_root_disconnect():
-        """Handle root namespace disconnect - typically during cleanup"""
 
     @_socketio.on("connect", namespace="/api/debug")
     def handle_connect(auth):

--- a/webserver/debug_websocket.py
+++ b/webserver/debug_websocket.py
@@ -42,9 +42,16 @@ def init_debug_websocket(app, unix_client_instance):
 
     @_socketio.on("connect")
     def handle_root_connect():
-        """Reject connections to root namespace - must use /api/debug"""
-        logger.warning("Connection attempt to root namespace - rejecting")
-        return False
+        """
+        Handle root namespace connections.
+        These typically occur during client disconnect polling fallback.
+        We silently accept but don't provide any functionality.
+        """
+        return True
+
+    @_socketio.on("disconnect")
+    def handle_root_disconnect():
+        """Handle root namespace disconnect - typically during cleanup"""
 
     @_socketio.on("connect", namespace="/api/debug")
     def handle_connect(auth):


### PR DESCRIPTION
This pull request introduces a new debug command interface for the PLC application, enabling external clients to interact with internal variables and debugging features over the UNIX socket. The main changes include adding a `debug_handler` module, extending the UNIX socket command handling, updating buffer sizes, and introducing utility functions for hex string parsing and formatting. Additionally, several new function pointers are loaded for interacting with debug-related features in the plugin system.

**Debug command interface and handler:**

* Added a new `debug_handler` module (`debug_handler.c`, `debug_handler.h`) that implements processing of debug commands, including functions for info retrieval, variable tracing, and MD5 checks. This module exposes `process_debug_data` for handling debug data frames. [[1]](diffhunk://#diff-252449af8f82d4f7cf0ebde2c253a18a4a861cd08f9a9b2c2cda7bae298a7feaR1-R268) [[2]](diffhunk://#diff-1ed7e1ce64b7f7d0dc9f3d67695ef00f5e924f9c7d48865955f292560a961ac6R1-R11) [[3]](diffhunk://#diff-fe32b3fad24b74ef4226befd87c5543302575a5ca3bd00284713e13b21f3e591R36)
* Integrated the debug handler into the UNIX socket command processor, allowing commands prefixed with `DEBUG:` to be parsed, processed, and responded to in hex format. [[1]](diffhunk://#diff-316cde074ac8e36d9ee328f7ab8fbf3551b100818c1fe7abc1f65c4f02578dc9R97-R118) [[2]](diffhunk://#diff-316cde074ac8e36d9ee328f7ab8fbf3551b100818c1fe7abc1f65c4f02578dc9L1-L15) [[3]](diffhunk://#diff-ef59c35b0bcbe9f6fc8042f561433a9c708fd346723c2c25940283c4d891a96eL5-R6)

**Plugin debug symbol integration:**

* Declared and loaded new function pointers for debug operations in the plugin manager, including variable count, size, address, trace setting, and endianness configuration. Updated symbol loading checks to ensure all debug symbols are present. [[1]](diffhunk://#diff-c7f53e81227128b7f49182c2e9730a8d63d4815873188ec6c94b1e19dcd0337dR47-R55) [[2]](diffhunk://#diff-c7f53e81227128b7f49182c2e9730a8d63d4815873188ec6c94b1e19dcd0337dR77-R96) [[3]](diffhunk://#diff-c0df27bf473e3e8655cef425596653afca2e630643edcc0a038c59a30fcd6785R68-R76)

**Utility enhancements:**

* Added `parse_hex_string` and `bytes_to_hex_string` utility functions to convert between hex strings and byte arrays, facilitating the new debug command interface. [[1]](diffhunk://#diff-3669521805c016b1e62888f70202c74c45b8e586131348c04e801d9f3c3557f4R56-R149) [[2]](diffhunk://#diff-bbdc6f9cae36824b4271e497db9415d85e7c6c375e5f575ce900b2103544d24bR44-R63) [[3]](diffhunk://#diff-bbdc6f9cae36824b4271e497db9415d85e7c6c375e5f575ce900b2103544d24bR7)

**Configuration and housekeeping:**

* Increased `COMMAND_BUFFER_SIZE` and `MAX_RESPONSE_SIZE` in `unix_socket.h` to 8192 bytes to support larger debug frames.
* Updated pre-commit configuration: added `W0511` to pylint disables and commented out the `mypy` hook. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L8-R8) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L29-R32)