### PR TITLE
Fix user retention

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -357,6 +357,15 @@ if is_msys2; then
 else
     mkdir -p /var/run/runtime
     chmod 775 /var/run/runtime 2>/dev/null || true  # Ignore permission errors in Docker
+
+    # Create persistent data directory for native Linux installs
+    # This directory stores .env and database files that must survive reboot
+    # In Docker, /var/run/runtime is mounted as a persistent volume instead
+    if has_systemd_support; then
+        mkdir -p /var/lib/openplc-runtime
+        chmod 755 /var/lib/openplc-runtime
+        log_info "Created persistent data directory at /var/lib/openplc-runtime"
+    fi
 fi
 
 # Make scripts executable


### PR DESCRIPTION
This pull request improves the handling of runtime and persistent data directories for both containerized and native Linux installations. The changes ensure that data such as the `.env` file and database are stored in the correct location depending on the environment, increasing robustness and making sure persistent data survives system reboots outside containers. A new utility function also detects whether the application is running inside a container.

**Persistent data management improvements:**

* Added the `get_persistent_data_dir()` function in `webserver/config.py` to select the appropriate directory for persistent data based on whether the app is running in a container or on native Linux/MSYS2. Persistent data is now stored in `/var/lib/openplc-runtime` on native Linux, and `/var/run/runtime` in containers and MSYS2/Windows.
* Updated the definitions of `ENV_PATH` and `DB_PATH` in `webserver/config.py` to use the new persistent data directory, ensuring these files are stored in a location that survives reboots on native Linux.

**Container detection and directory setup:**

* Added the `is_running_in_container()` function in `webserver/config.py` to robustly detect if the application is running inside a container using multiple heuristics.
* Modified `install.sh` to create `/var/lib/openplc-runtime` with appropriate permissions for native Linux installs with systemd support, ensuring the persistent data directory exists.

**Documentation and comments:**

* Improved comments in `webserver/config.py` to clarify the logic for selecting runtime and persistent data directories depending on platform and environment.