### PR TITLE
fix: Prevent deadlock when stopping PLC with plugins

### DIFF
--- a/core/src/drivers/plugin_driver.c
+++ b/core/src/drivers/plugin_driver.c
@@ -282,7 +282,8 @@ int plugin_driver_init(plugin_driver_t *driver)
     }
 
     // Only acquire Python GIL if we have Python plugins and Python is initialized
-    PyGILState_STATE local_gstate;
+    // Initialize to PyGILState_LOCKED (0) to satisfy compiler warning
+    PyGILState_STATE local_gstate = PyGILState_LOCKED;
     int have_gil = has_python_plugin && Py_IsInitialized();
     if (have_gil)
     {
@@ -624,7 +625,8 @@ void plugin_driver_destroy(plugin_driver_t *driver)
 
     // Check if Python is initialized before any Python operations
     int python_initialized = has_python_plugin && Py_IsInitialized();
-    PyGILState_STATE local_gstate;
+    // Initialize to PyGILState_LOCKED (0) to satisfy compiler warning
+    PyGILState_STATE local_gstate = PyGILState_LOCKED;
 
     if (python_initialized)
     {

--- a/core/src/drivers/plugin_driver.c
+++ b/core/src/drivers/plugin_driver.c
@@ -282,7 +282,7 @@ int plugin_driver_init(plugin_driver_t *driver)
     }
 
     // Only acquire Python GIL if we have Python plugins and Python is initialized
-    PyGILState_STATE local_gstate = 0;
+    PyGILState_STATE local_gstate;
     int have_gil = has_python_plugin && Py_IsInitialized();
     if (have_gil)
     {
@@ -624,7 +624,7 @@ void plugin_driver_destroy(plugin_driver_t *driver)
 
     // Check if Python is initialized before any Python operations
     int python_initialized = has_python_plugin && Py_IsInitialized();
-    PyGILState_STATE local_gstate = 0;
+    PyGILState_STATE local_gstate;
 
     if (python_initialized)
     {
@@ -664,7 +664,10 @@ void plugin_driver_destroy(plugin_driver_t *driver)
     if (python_initialized)
     {
         PyGILState_Release(local_gstate);
-        PyEval_RestoreThread(main_tstate);
+        if (main_tstate != NULL)
+        {
+            PyEval_RestoreThread(main_tstate);
+        }
         Py_FinalizeEx();
     }
 


### PR DESCRIPTION
## Summary
- Fixes deadlock when stopping PLC with S7Comm plugin connected
- Fixes hang when stopping PLC without Python plugins

## Problem

### Issue 1: Deadlock with S7Comm plugin
When stopping the PLC while an S7Comm client was connected, the runtime would deadlock:
1. `unload_plc_program()` tried to acquire `buffer_mutex`
2. S7Comm's RWArea callback was holding `buffer_mutex` during client read operations
3. Result: deadlock - neither could proceed

### Issue 2: Hang without Python plugins
When stopping the PLC with no Python plugins enabled (or with only native plugins like S7Comm), the runtime would hang because Python GIL functions were called unconditionally even when Python wasn't initialized.

## Solution

### Fix 1: Reorder plugin stop and mutex acquisition (plc_state_manager.c)
```c
// Stop plugins FIRST (before acquiring mutex) to prevent deadlock
plugin_driver_stop(plugin_driver);

// Clear temporary pointers from image tables before unloading
plugin_mutex_take(&plugin_driver->buffer_mutex);
image_tables_clear_null_pointers();
plugin_mutex_give(&plugin_driver->buffer_mutex);
```

### Fix 2: Guard Python GIL operations (plugin_driver.c)
Added `has_python_plugin && Py_IsInitialized()` checks before all Python GIL operations in:
- `plugin_driver_init()`
- `plugin_driver_start()`
- `plugin_driver_stop()`
- `plugin_driver_restart()`
- `plugin_driver_destroy()`

## Test plan
- [ ] Start PLC with S7Comm server enabled
- [ ] Connect an S7 client (e.g., Snap7 client)
- [ ] Stop PLC while client is connected - verify no deadlock
- [ ] Start PLC with only native plugins (no Python plugins)
- [ ] Stop PLC - verify no hang
- [ ] Start PLC with Python plugins (e.g., Modbus)
- [ ] Stop PLC - verify normal shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)