### PR TITLE
Fixes from development branch

### DIFF
--- a/core/src/drivers/plugin_driver.c
+++ b/core/src/drivers/plugin_driver.c
@@ -282,7 +282,8 @@ int plugin_driver_init(plugin_driver_t *driver)
     }
 
     // Only acquire Python GIL if we have Python plugins and Python is initialized
-    PyGILState_STATE local_gstate;
+    // Initialize to PyGILState_LOCKED (0) to satisfy compiler warning
+    PyGILState_STATE local_gstate = PyGILState_LOCKED;
     int have_gil = has_python_plugin && Py_IsInitialized();
     if (have_gil)
     {
@@ -624,7 +625,8 @@ void plugin_driver_destroy(plugin_driver_t *driver)
 
     // Check if Python is initialized before any Python operations
     int python_initialized = has_python_plugin && Py_IsInitialized();
-    PyGILState_STATE local_gstate;
+    // Initialize to PyGILState_LOCKED (0) to satisfy compiler warning
+    PyGILState_STATE local_gstate = PyGILState_LOCKED;
 
     if (python_initialized)
     {

--- a/core/src/drivers/plugin_driver.c
+++ b/core/src/drivers/plugin_driver.c
@@ -282,7 +282,7 @@ int plugin_driver_init(plugin_driver_t *driver)
     }
 
     // Only acquire Python GIL if we have Python plugins and Python is initialized
-    PyGILState_STATE local_gstate = 0;
+    PyGILState_STATE local_gstate;
     int have_gil = has_python_plugin && Py_IsInitialized();
     if (have_gil)
     {
@@ -624,7 +624,7 @@ void plugin_driver_destroy(plugin_driver_t *driver)
 
     // Check if Python is initialized before any Python operations
     int python_initialized = has_python_plugin && Py_IsInitialized();
-    PyGILState_STATE local_gstate = 0;
+    PyGILState_STATE local_gstate;
 
     if (python_initialized)
     {
@@ -664,7 +664,10 @@ void plugin_driver_destroy(plugin_driver_t *driver)
     if (python_initialized)
     {
         PyGILState_Release(local_gstate);
-        PyEval_RestoreThread(main_tstate);
+        if (main_tstate != NULL)
+        {
+            PyEval_RestoreThread(main_tstate);
+        }
         Py_FinalizeEx();
     }
 


### PR DESCRIPTION
This pull request improves the safety and robustness of plugin driver lifecycle management, especially around the use of the Python Global Interpreter Lock (GIL) and destruction order. The changes ensure that Python-related operations are only performed when the Python interpreter is initialized, and that resource cleanup avoids potential deadlocks and undefined behavior.

Key improvements include:

**Python GIL Management and Safety:**
- All plugin driver functions (`init`, `start`, `stop`, `restart`, and `destroy`) now check if Python is initialized (`Py_IsInitialized()`) before acquiring or releasing the GIL, preventing undefined behavior if Python is not available. [[1]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3L284-R291) [[2]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3R402-R407) [[3]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3L468-R502) [[4]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3R545-R548) [[5]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3L534-R571) [[6]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3R621-R641) [[7]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3R666-R674)
- The GIL is only released if it was previously acquired, and all GIL state variables are initialized to avoid compiler warnings. [[1]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3L284-R291) [[2]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3L468-R502) [[3]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3R666-R674)

**Resource Cleanup and Deadlock Prevention:**
- In `plugin_driver_destroy`, the mutex and driver memory are freed early if there are no plugins, preventing resource leaks.
- In `unload_plc_program`, the order of operations is changed to stop plugins before acquiring the buffer mutex, preventing a potential deadlock when plugins (like S7Comm) access the mutex during shutdown.

**Error Handling Improvements:**
- When plugin initialization or cleanup fails, the GIL is properly released only if it was acquired, ensuring consistent interpreter state and preventing resource leaks. [[1]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3R316-R319) [[2]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3R335-R338) [[3]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3R354-R357) [[4]](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3R368-R371)

These changes collectively make the plugin driver more robust, especially in mixed native/Python plugin environments and in scenarios where the Python interpreter may or may not be initialized.