### PR TITLE
fix: Address OPC-UA plugin security and code quality issues

### DIFF
--- a/core/src/drivers/plugin_utils.c
+++ b/core/src/drivers/plugin_utils.c
@@ -8,6 +8,12 @@
 // Returns NULL for all addresses if no PLC program is loaded
 void get_var_list(size_t num_vars, size_t *indexes, void **result)
 {
+    // Validate input parameters
+    if (!indexes || !result || num_vars == 0)
+    {
+        return;
+    }
+
     // Check if PLC program is loaded (function pointers are set)
     if (!ext_get_var_count || !ext_get_var_addr)
     {

--- a/core/src/drivers/plugins/python/opcua/opcua_security.py
+++ b/core/src/drivers/plugins/python/opcua/opcua_security.py
@@ -15,6 +15,7 @@ import socket
 import hashlib
 import asyncio
 import tempfile
+import shutil
 from pathlib import Path
 from typing import Optional, Tuple, List
 from urllib.parse import urlparse
@@ -764,7 +765,6 @@ class OpcuaSecurityManager:
         """
         if self._trust_store_temp_dir and os.path.exists(self._trust_store_temp_dir):
             try:
-                import shutil
                 shutil.rmtree(self._trust_store_temp_dir)
                 log_info(f"Cleaned up trust store temp directory: {self._trust_store_temp_dir}")
                 self._trust_store_temp_dir = None

--- a/core/src/drivers/plugins/python/opcua/opcua_security.py
+++ b/core/src/drivers/plugins/python/opcua/opcua_security.py
@@ -174,6 +174,7 @@ class OpcuaSecurityManager:
         self.security_policy = None
         self.security_mode = None
         self.trusted_certificates = []  # List of trusted client certificates
+        self._trust_store_temp_dir = None  # Track temp dir for cleanup
 
     async def initialize_security(self) -> bool:
         """
@@ -258,8 +259,8 @@ class OpcuaSecurityManager:
                 self.private_key_data = key_file.read()
 
             # Validate certificate format (basic check)
-                if not self._validate_certificate_format():
-                    return False
+            if not self._validate_certificate_format():
+                return False
 
             log_info(f"Server certificates loaded from {cert_path}")
             return True
@@ -289,14 +290,31 @@ class OpcuaSecurityManager:
                 import datetime
                 
                 cert = x509.load_pem_x509_certificate(self.certificate_data, default_backend())
-                
+
+                # Use timezone-aware datetime for comparison
+                now_utc = datetime.datetime.now(datetime.timezone.utc)
+
+                # Get certificate validity dates (prefer UTC versions if available)
+                not_valid_after = getattr(cert, 'not_valid_after_utc', None)
+                if not_valid_after is None:
+                    not_valid_after = cert.not_valid_after.replace(tzinfo=datetime.timezone.utc)
+
+                not_valid_before = getattr(cert, 'not_valid_before_utc', None)
+                if not_valid_before is None:
+                    not_valid_before = cert.not_valid_before.replace(tzinfo=datetime.timezone.utc)
+
+                # Check if certificate is not yet valid
+                if not_valid_before > now_utc:
+                    log_warn("Certificate is not yet valid")
+                    return False
+
                 # Check expiration
-                if cert.not_valid_after < datetime.datetime.now():
+                if not_valid_after < now_utc:
                     log_warn("Certificate has expired")
                     return False
-                
+
                 # Check if certificate will expire soon (within 30 days)
-                days_until_expiry = (cert.not_valid_after - datetime.datetime.now()).days
+                days_until_expiry = (not_valid_after - now_utc).days
                 if days_until_expiry < 30:
                     log_warn(f"Certificate expires in {days_until_expiry} days")
                 
@@ -704,6 +722,7 @@ class OpcuaSecurityManager:
         try:
             # Create temporary directory for certificate files
             temp_dir = tempfile.mkdtemp(prefix="opcua_trust_")
+            self._trust_store_temp_dir = temp_dir  # Store for cleanup
             cert_files = []
             
             for i, cert_pem in enumerate(trusted_certificates):
@@ -737,7 +756,21 @@ class OpcuaSecurityManager:
         except Exception as e:
             log_error(f"Failed to create TrustStore: {e}")
             return None
-    
+
+    def cleanup(self) -> None:
+        """Clean up resources including temporary directories.
+
+        Should be called when the server is shutting down.
+        """
+        if self._trust_store_temp_dir and os.path.exists(self._trust_store_temp_dir):
+            try:
+                import shutil
+                shutil.rmtree(self._trust_store_temp_dir)
+                log_info(f"Cleaned up trust store temp directory: {self._trust_store_temp_dir}")
+                self._trust_store_temp_dir = None
+            except Exception as e:
+                log_warn(f"Failed to clean up trust store temp directory: {e}")
+
     async def setup_certificate_validation(self, server, trusted_certificates) -> None:
         """Setup certificate validation for asyncua Server.
         

--- a/core/src/drivers/plugins/python/opcua/requirements.txt
+++ b/core/src/drivers/plugins/python/opcua/requirements.txt
@@ -5,6 +5,9 @@ asyncua==1.1.8
 # System monitoring and performance metrics
 psutil==7.2.1
 
+# Password hashing for user authentication (required for security)
+bcrypt>=4.0.0
+
 # Core dependencies (automatically installed with asyncua)
 # cryptography>=3.4.8        # For OPC-UA security features
 # python-dateutil>=2.8.0     # For datetime handling in OPC-UA

--- a/core/src/drivers/plugins/python/opcua/server.py
+++ b/core/src/drivers/plugins/python/opcua/server.py
@@ -319,6 +319,10 @@ class OpcuaServerManager:
             self.running = False
             self.server = None
 
+            # Clean up security manager resources (temp directories, etc.)
+            if self.security_manager:
+                self.security_manager.cleanup()
+
         except Exception as e:
             log_error(f"Error during cleanup: {e}")
 


### PR DESCRIPTION
## Summary
- Fix indentation error in certificate validation that could cause runtime issues
- Add `bcrypt>=4.0.0` as required dependency for password authentication security
- Add cleanup for trust store temp directories to prevent disk space exhaustion
- Use timezone-aware datetime for certificate expiry checks (compatibility with cryptography library)
- Add not-yet-valid certificate check (was missing)
- Add null parameter validation in C code (`plugin_utils.c`)

## Test plan
- [x] Verify OPC-UA server starts without errors
- [x] Verify certificate validation works correctly
- [ ] Verify temp directories are cleaned up on server shutdown
- [ ] Verify `bcrypt` is installed from requirements.txt
- [x] Build C code to verify null checks compile correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)