### PR TITLE
feat: Add nested structures support for OPC-UA address space

### DIFF
--- a/core/src/drivers/plugins/python/opcua/address_space.py
+++ b/core/src/drivers/plugins/python/opcua/address_space.py
@@ -234,6 +234,10 @@ class AddressSpaceBuilder:
         """
         Create a field within a struct.
 
+        Supports nested fields for complex types (FB instances, nested structs).
+        When a field has nested fields, creates an Object node and recursively
+        creates child fields. Leaf fields (no nested fields) create Variable nodes.
+
         Args:
             parent_node: Parent struct object node
             struct_node_id: Parent struct's node_id for building field path
@@ -241,6 +245,31 @@ class AddressSpaceBuilder:
         """
         field_node_id = f"{struct_node_id}.{field.name}"
 
+        # Check if this is a complex type with nested fields
+        if field.fields and len(field.fields) > 0:
+            # Create an Object node for complex types (FB instances, nested structs)
+            field_obj = await parent_node.add_object(
+                self.namespace_idx,
+                field.name
+            )
+
+            # Set display name
+            await field_obj.write_attribute(
+                ua.AttributeIds.DisplayName,
+                ua.DataValue(ua.Variant(
+                    ua.LocalizedText(field.name),
+                    ua.VariantType.LocalizedText
+                ))
+            )
+
+            # Recursively create nested fields
+            for nested_field in field.fields:
+                await self._create_struct_field(field_obj, field_node_id, nested_field)
+
+            log_info(f"Created nested object {field_node_id} with {len(field.fields)} fields")
+            return
+
+        # This is a leaf field - create a Variable node
         opcua_type = map_plc_to_opcua_type(field.datatype)
         initial_value = convert_value_for_opcua(field.datatype, field.initial_value)
 
@@ -266,21 +295,24 @@ class AddressSpaceBuilder:
         if has_write_permission:
             await node.set_writable()
 
-        # Store node mapping
-        access_mode = "readwrite" if has_write_permission else "readonly"
-        var_node = VariableNode(
-            node=node,
-            debug_var_index=field.index,
-            datatype=field.datatype,
-            access_mode=access_mode,
-            is_array_element=False
-        )
+        # Store node mapping (only for leaf fields with valid indices)
+        if field.index is not None:
+            access_mode = "readwrite" if has_write_permission else "readonly"
+            var_node = VariableNode(
+                node=node,
+                debug_var_index=field.index,
+                datatype=field.datatype,
+                access_mode=access_mode,
+                is_array_element=False
+            )
 
-        self.variable_nodes[field.index] = var_node
-        self.node_permissions[field_node_id] = field.permissions
-        self.nodeid_to_variable[node.nodeid] = field_node_id
+            self.variable_nodes[field.index] = var_node
+            self.node_permissions[field_node_id] = field.permissions
+            self.nodeid_to_variable[node.nodeid] = field_node_id
 
-        log_info(f"Created field {field_node_id} (index: {field.index})")
+            log_info(f"Created field {field_node_id} (index: {field.index})")
+        else:
+            log_warn(f"Field {field_node_id} has no index - skipping node mapping")
 
     async def _create_array(
         self,

--- a/core/src/drivers/plugins/python/opcua/address_space.py
+++ b/core/src/drivers/plugins/python/opcua/address_space.py
@@ -312,7 +312,8 @@ class AddressSpaceBuilder:
 
             log_info(f"Created field {field_node_id} (index: {field.index})")
         else:
-            log_warn(f"Field {field_node_id} has no index - skipping node mapping")
+            # Complex types (FBs, nested structs) have null indices - only leaf fields have indices
+            log_info(f"Field {field_node_id} is a complex type (no index) - skipping node mapping")
 
     async def _create_array(
         self,

--- a/core/src/drivers/plugins/python/shared/plugin_config_decode/opcua_config_model.py
+++ b/core/src/drivers/plugins/python/shared/plugin_config_decode/opcua_config_model.py
@@ -147,12 +147,19 @@ class VariablePermissions:
 
 @dataclass
 class VariableField:
-    """Field within a struct variable."""
+    """
+    Field within a struct variable.
+
+    Supports nested fields for complex types (FB instances, nested structs).
+    When a field has nested fields, its index will be None since only leaf
+    fields have actual debug variable indices.
+    """
     name: str
     datatype: str
     initial_value: Any
-    index: int
+    index: Optional[int]  # None for complex types that have nested fields
     permissions: VariablePermissions
+    fields: Optional[List['VariableField']] = None  # Nested fields for complex types
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'VariableField':
@@ -161,19 +168,25 @@ class VariableField:
             name = data["name"]
             datatype = data["datatype"]
             initial_value = data["initial_value"]
-            index = data["index"]
+            index = data["index"]  # Can be None for complex types
             permissions_data = data["permissions"]
         except KeyError as e:
             raise ValueError(f"Missing required field in variable field: {e}")
 
         permissions = VariablePermissions.from_dict(permissions_data)
 
+        # Parse nested fields if present (recursive)
+        nested_fields = None
+        if "fields" in data and data["fields"]:
+            nested_fields = [VariableField.from_dict(f) for f in data["fields"]]
+
         return cls(
             name=name,
             datatype=datatype,
             initial_value=initial_value,
             index=index,
-            permissions=permissions
+            permissions=permissions,
+            fields=nested_fields
         )
 
 @dataclass
@@ -422,10 +435,20 @@ class OpcuaMasterConfig(PluginConfigContract):
                 raise ValueError(f"Duplicate node_ids found in plugin '{plugin.name}'")
 
             # Check for duplicate indices
+            # Helper to collect indices recursively from nested fields
+            def collect_field_indices(fields: List[VariableField]) -> List[int]:
+                indices = []
+                for field in fields:
+                    if field.index is not None:  # Skip None indices (complex types)
+                        indices.append(field.index)
+                    if field.fields:  # Recurse into nested fields
+                        indices.extend(collect_field_indices(field.fields))
+                return indices
+
             all_indices = []
             all_indices.extend([var.index for var in address_space.variables])
             for struct in address_space.structures:
-                all_indices.extend([field.index for field in struct.fields])
+                all_indices.extend(collect_field_indices(struct.fields))
             all_indices.extend([arr.index for arr in address_space.arrays])
 
             if len(all_indices) != len(set(all_indices)):


### PR DESCRIPTION
## Summary
- Add support for nested structures in OPC-UA address space builder
- FB instances (like TON inside custom FBs) now appear as expandable OPC-UA Object nodes instead of flat Variable nodes
- Runtime properly handles hierarchical field configuration from editor

## Changes
- Update `VariableField` dataclass with optional `fields` property for recursive nesting
- Update `index` to `Optional[int]` (None for complex types)
- Update `_create_struct_field()` to create Object nodes for complex fields and recurse
- Fix validation to skip None indices and collect indices recursively from nested fields

## Test plan
- [ ] Run OPC-UA server with nested structure configuration
- [ ] Verify nested FBs appear as expandable Object nodes in UaExpert
- [ ] Verify leaf variables are readable/writable
- [ ] Verify synchronization works correctly for nested leaf variables

🤖 Generated with [Claude Code](https://claude.ai/code)