### PR TITLE
feat: Add brute-force protection and asyncua User class integration

### DIFF
--- a/core/src/drivers/plugins/python/opcua/user_manager.py
+++ b/core/src/drivers/plugins/python/opcua/user_manager.py
@@ -3,20 +3,24 @@ OPC UA User Manager.
 
 This module provides authentication and user management for the OPC-UA server.
 It supports password authentication, certificate authentication, and anonymous access.
+Includes brute-force protection with rate limiting.
 """
 
 import base64
 import hashlib
 import os
 import sys
-from types import SimpleNamespace
-from typing import Optional, Any
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
+from asyncua.crypto.permission_rules import User
 from asyncua.server.user_managers import UserManager, UserRole
 
 # Import bcrypt with fallback
 try:
     import bcrypt
+
     _bcrypt_available = True
 except ImportError:
     _bcrypt_available = False
@@ -31,11 +35,163 @@ if _parent_dir not in sys.path:
 
 # Import logging (handle both package and direct loading)
 try:
-    from .opcua_logging import log_info, log_warn, log_error
+    from .opcua_logging import log_error, log_info, log_warn
 except ImportError:
     from opcua_logging import log_info, log_warn, log_error
 
-from shared.plugin_config_decode.opcua_config_model import OpcuaConfig
+from shared.plugin_config_decode.opcua_config_model import OpcuaConfig  # noqa: E402
+
+# Rate limiting constants
+DEFAULT_MAX_ATTEMPTS = 5
+DEFAULT_LOCKOUT_DURATION_SECONDS = 300  # 5 minutes
+DEFAULT_ATTEMPT_WINDOW_SECONDS = 60  # 1 minute window for counting attempts
+
+
+@dataclass
+class AuthAttemptTracker:
+    """Tracks authentication attempts for rate limiting."""
+
+    attempts: int = 0
+    first_attempt_time: float = 0.0
+    lockout_until: float = 0.0
+
+
+@dataclass
+class RateLimitConfig:
+    """Configuration for rate limiting."""
+
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS
+    lockout_duration_seconds: float = DEFAULT_LOCKOUT_DURATION_SECONDS
+    attempt_window_seconds: float = DEFAULT_ATTEMPT_WINDOW_SECONDS
+
+
+class RateLimiter:
+    """
+    Rate limiter for authentication attempts.
+
+    Tracks failed authentication attempts per identifier (username or IP)
+    and enforces lockout after too many failures.
+    """
+
+    def __init__(self, config: Optional[RateLimitConfig] = None):
+        """
+        Initialize the rate limiter.
+
+        Args:
+            config: Rate limit configuration. Uses defaults if not provided.
+        """
+        self.config = config or RateLimitConfig()
+        self._trackers: Dict[str, AuthAttemptTracker] = {}
+
+    def is_locked_out(self, identifier: str) -> bool:
+        """
+        Check if an identifier is currently locked out.
+
+        Args:
+            identifier: The identifier to check (username, IP, etc.)
+
+        Returns:
+            True if locked out, False otherwise
+        """
+        tracker = self._trackers.get(identifier)
+        if not tracker:
+            return False
+
+        current_time = time.time()
+
+        # Check if lockout has expired
+        if tracker.lockout_until > 0 and current_time < tracker.lockout_until:
+            return True
+
+        # Reset if lockout expired
+        if tracker.lockout_until > 0 and current_time >= tracker.lockout_until:
+            self._reset_tracker(identifier)
+            return False
+
+        return False
+
+    def get_lockout_remaining(self, identifier: str) -> float:
+        """
+        Get remaining lockout time in seconds.
+
+        Args:
+            identifier: The identifier to check
+
+        Returns:
+            Remaining lockout time in seconds, or 0 if not locked out
+        """
+        tracker = self._trackers.get(identifier)
+        if not tracker or tracker.lockout_until <= 0:
+            return 0.0
+
+        remaining = tracker.lockout_until - time.time()
+        return max(0.0, remaining)
+
+    def record_attempt(self, identifier: str, success: bool) -> None:
+        """
+        Record an authentication attempt.
+
+        Args:
+            identifier: The identifier (username, IP, etc.)
+            success: Whether the attempt was successful
+        """
+        current_time = time.time()
+
+        if success:
+            # Reset on successful authentication
+            self._reset_tracker(identifier)
+            return
+
+        # Get or create tracker
+        if identifier not in self._trackers:
+            self._trackers[identifier] = AuthAttemptTracker(
+                attempts=0, first_attempt_time=current_time, lockout_until=0.0
+            )
+
+        tracker = self._trackers[identifier]
+
+        # Reset attempt count if window has expired
+        if current_time - tracker.first_attempt_time > self.config.attempt_window_seconds:
+            tracker.attempts = 0
+            tracker.first_attempt_time = current_time
+
+        # Increment attempt count
+        tracker.attempts += 1
+
+        # Check if lockout threshold reached
+        if tracker.attempts >= self.config.max_attempts:
+            tracker.lockout_until = current_time + self.config.lockout_duration_seconds
+
+    def _reset_tracker(self, identifier: str) -> None:
+        """Reset the tracker for an identifier."""
+        if identifier in self._trackers:
+            del self._trackers[identifier]
+
+    def cleanup_expired(self) -> int:
+        """
+        Clean up expired trackers to prevent memory growth.
+
+        Returns:
+            Number of trackers removed
+        """
+        current_time = time.time()
+        expired = []
+
+        for identifier, tracker in self._trackers.items():
+            # Remove if lockout expired and no recent attempts
+            if tracker.lockout_until > 0 and current_time >= tracker.lockout_until:
+                expired.append(identifier)
+            # Remove if attempt window expired and not locked out
+            elif (
+                tracker.lockout_until <= 0
+                and current_time - tracker.first_attempt_time > self.config.attempt_window_seconds
+            ):
+                expired.append(identifier)
+
+        for identifier in expired:
+            del self._trackers[identifier]
+
+        return len(expired)
 
 
 class OpenPLCUserManager(UserManager):
@@ -46,58 +202,73 @@ class OpenPLCUserManager(UserManager):
     - Password authentication (bcrypt hashed)
     - Certificate authentication (fingerprint matching)
     - Anonymous access
+    - Brute-force protection with rate limiting
 
     Maps OpenPLC roles to asyncua UserRole enum:
     - viewer -> UserRole.User (read-only)
     - operator -> UserRole.User (read/write via callbacks)
     - engineer -> UserRole.Admin (full access)
+
+    Returns asyncua User objects for proper integration with the asyncua library.
     """
 
     # Map OpenPLC roles to asyncua UserRole enum
     ROLE_MAPPING = {
-        "viewer": UserRole.User,      # Read-only access
-        "operator": UserRole.User,    # Read/write access (controlled by callbacks)
-        "engineer": UserRole.Admin    # Full access
+        "viewer": UserRole.User,  # Read-only access
+        "operator": UserRole.User,  # Read/write access (controlled by callbacks)
+        "engineer": UserRole.Admin,  # Full access
     }
 
-    def __init__(self, config: OpcuaConfig):
+    def __init__(self, config: OpcuaConfig, rate_limit_config: Optional[RateLimitConfig] = None):
         """
         Initialize the user manager.
 
         Args:
             config: OpcuaConfig instance with users and security profiles
+            rate_limit_config: Optional rate limiting configuration.
+                              Uses defaults if not provided.
         """
         super().__init__()
         self.config = config
 
+        # Initialize rate limiter for brute-force protection
+        self.rate_limiter = RateLimiter(rate_limit_config)
+
         # Build user dictionaries
-        self.users = {
-            user.username: user
-            for user in config.users
-            if user.type == "password"
-        }
+        self.users = {user.username: user for user in config.users if user.type == "password"}
         self.cert_users = {
-            user.certificate_id: user
-            for user in config.users
-            if user.type == "certificate"
+            user.certificate_id: user for user in config.users if user.type == "certificate"
         }
 
-        log_info(f"UserManager initialized: {len(self.users)} password users, "
-                 f"{len(self.cert_users)} certificate users")
+        # Store OpenPLC roles separately to avoid modifying config objects
+        self._user_roles: Dict[str, str] = {}
+        for user in config.users:
+            if user.type == "password" and user.username:
+                self._user_roles[user.username] = str(user.role)
+            elif user.type == "certificate" and user.certificate_id:
+                self._user_roles[f"cert:{user.certificate_id}"] = str(user.role)
+
+        log_info(
+            f"UserManager initialized: {len(self.users)} password users, "
+            f"{len(self.cert_users)} certificate users, rate limiting enabled"
+        )
 
     def get_user(
         self,
         iserver,
         username: Optional[str] = None,
         password: Optional[str] = None,
-        certificate: Optional[Any] = None
-    ) -> Optional[Any]:
+        certificate: Optional[Any] = None,
+    ) -> Optional[User]:
         """
-        Authenticate user with security profile enforcement.
+        Authenticate user with security profile enforcement and rate limiting.
 
         Note: asyncua passes InternalServer as the first argument, not a session.
         The security policy URI is not available at this level, so we select
         the security profile based on the authentication method being used.
+
+        Rate limiting is applied to prevent brute-force attacks. After too many
+        failed attempts, the user/identifier is locked out for a configurable period.
 
         Args:
             iserver: The internal server object (passed by asyncua)
@@ -106,10 +277,24 @@ class OpenPLCUserManager(UserManager):
             certificate: Certificate for certificate authentication
 
         Returns:
-            User object with role attribute, or None if authentication fails
+            asyncua User object with role attribute, or None if authentication fails
         """
         # Detect authentication method from provided credentials
         auth_method = self._detect_auth_method(username, password, certificate)
+
+        # Determine rate limit identifier based on auth method
+        rate_limit_id = self._get_rate_limit_identifier(username, certificate)
+
+        # Check rate limiting (skip for anonymous)
+        if auth_method != "Anonymous" and rate_limit_id:
+            if self.rate_limiter.is_locked_out(rate_limit_id):
+                remaining = self.rate_limiter.get_lockout_remaining(rate_limit_id)
+                log_warn(
+                    f"Authentication blocked for '{rate_limit_id}': "
+                    f"locked out for {remaining:.0f} more seconds"
+                )
+                return None
+
         log_info(f"Authentication attempt: method={auth_method}")
 
         # Find a security profile that supports this authentication method
@@ -119,26 +304,37 @@ class OpenPLCUserManager(UserManager):
             log_error(
                 f"No security profile found that supports authentication method '{auth_method}'"
             )
+            # Record failed attempt for rate limiting
+            if rate_limit_id:
+                self.rate_limiter.record_attempt(rate_limit_id, success=False)
             return None
 
         log_info(f"Using security profile '{profile.name}' for {auth_method} authentication")
 
         # Authenticate based on method
         user = None
+        openplc_role = None
 
         if auth_method == "Username" and username and password:
-            user = self._authenticate_password(username, password)
+            user, openplc_role = self._authenticate_password(username, password)
 
         elif auth_method == "Certificate" and certificate:
-            user = self._authenticate_certificate(certificate)
+            user, openplc_role = self._authenticate_certificate(certificate)
 
         elif auth_method == "Anonymous":
-            user = self._authenticate_anonymous(profile)
+            user, openplc_role = self._authenticate_anonymous(profile)
+
+        # Record attempt result for rate limiting (skip anonymous)
+        if auth_method != "Anonymous" and rate_limit_id:
+            self.rate_limiter.record_attempt(rate_limit_id, success=(user is not None))
 
         if user:
+            # Store OpenPLC role as attribute for permission callbacks
+            user.openplc_role = openplc_role
             log_info(
-                f"User '{getattr(user, 'username', 'anonymous')}' authenticated successfully "
-                f"using '{auth_method}' method for profile '{profile.name}'"
+                f"User '{user.name or 'anonymous'}' authenticated successfully "
+                f"using '{auth_method}' method for profile '{profile.name}' "
+                f"(role: {openplc_role})"
             )
             return user
         else:
@@ -147,7 +343,30 @@ class OpenPLCUserManager(UserManager):
             )
             return None
 
-    def _authenticate_password(self, username: str, password: str) -> Optional[Any]:
+    def _get_rate_limit_identifier(
+        self, username: Optional[str], certificate: Optional[Any]
+    ) -> Optional[str]:
+        """
+        Get identifier for rate limiting.
+
+        Args:
+            username: Username if provided
+            certificate: Certificate if provided
+
+        Returns:
+            Identifier string for rate limiting, or None
+        """
+        if username:
+            return f"user:{username}"
+        elif certificate:
+            fingerprint = self._cert_to_fingerprint(certificate)
+            if fingerprint:
+                return f"cert:{fingerprint[:32]}"  # Use first 32 chars of fingerprint
+        return None
+
+    def _authenticate_password(
+        self, username: str, password: str
+    ) -> tuple[Optional[User], Optional[str]]:
         """
         Authenticate using username and password.
 
@@ -156,23 +375,25 @@ class OpenPLCUserManager(UserManager):
             password: The password
 
         Returns:
-            User object or None
+            Tuple of (asyncua User object, OpenPLC role string) or (None, None)
         """
         if username not in self.users:
             log_warn(f"User '{username}' not found in configuration")
-            return None
+            return None, None
 
-        user = self.users[username]
-        if not self._validate_password(password, user.password_hash):
+        config_user = self.users[username]
+        if not self._validate_password(password, config_user.password_hash):
             log_warn(f"Password validation failed for user '{username}'")
-            return None
+            return None, None
 
-        # Add asyncua-compatible role and preserve OpenPLC role
-        user.openplc_role = str(user.role)  # Ensure it's a string
-        user.role = self.ROLE_MAPPING.get(user.openplc_role, UserRole.User)
-        return user
+        # Get OpenPLC role and map to asyncua role
+        openplc_role = self._user_roles.get(username, "viewer")
+        asyncua_role = self.ROLE_MAPPING.get(openplc_role, UserRole.User)
 
-    def _authenticate_certificate(self, certificate: Any) -> Optional[Any]:
+        # Return asyncua User object
+        return User(role=asyncua_role, name=username), openplc_role
+
+    def _authenticate_certificate(self, certificate: Any) -> tuple[Optional[User], Optional[str]]:
         """
         Authenticate using certificate.
 
@@ -180,21 +401,23 @@ class OpenPLCUserManager(UserManager):
             certificate: The client certificate
 
         Returns:
-            User object or None
+            Tuple of (asyncua User object, OpenPLC role string) or (None, None)
         """
         cert_id = self._extract_cert_id(certificate)
         if not cert_id or cert_id not in self.cert_users:
             log_warn(f"Certificate not found in trusted certificates (cert_id={cert_id})")
-            return None
+            return None, None
 
-        user = self.cert_users[cert_id]
-        # Add asyncua-compatible role and preserve OpenPLC role
-        user.openplc_role = str(user.role)  # Ensure it's a string
-        user.role = self.ROLE_MAPPING.get(user.openplc_role, UserRole.User)
-        log_info(f"Certificate authenticated as user with role '{user.openplc_role}'")
-        return user
+        # Get OpenPLC role and map to asyncua role
+        openplc_role = self._user_roles.get(f"cert:{cert_id}", "viewer")
+        asyncua_role = self.ROLE_MAPPING.get(openplc_role, UserRole.User)
 
-    def _authenticate_anonymous(self, profile: Any) -> Optional[Any]:
+        log_info(f"Certificate authenticated as user with role '{openplc_role}'")
+
+        # Return asyncua User object
+        return User(role=asyncua_role, name=f"cert:{cert_id}"), openplc_role
+
+    def _authenticate_anonymous(self, profile: Any) -> tuple[Optional[User], Optional[str]]:
         """
         Authenticate as anonymous user.
 
@@ -202,17 +425,17 @@ class OpenPLCUserManager(UserManager):
             profile: The security profile
 
         Returns:
-            Anonymous user object or None
+            Tuple of (asyncua User object, OpenPLC role string) or (None, None)
         """
         if "Anonymous" not in profile.auth_methods:
             log_warn("Anonymous authentication not allowed for this profile")
-            return None
+            return None, None
 
-        user = SimpleNamespace()
-        user.username = "anonymous"
-        user.openplc_role = "viewer"
-        user.role = UserRole.User  # Map to asyncua UserRole enum
-        return user
+        # Anonymous users get viewer role (read-only)
+        openplc_role = "viewer"
+
+        # Return asyncua User object
+        return User(role=UserRole.User, name="anonymous"), openplc_role
 
     def _extract_cert_id(self, certificate: Any) -> Optional[str]:
         """
@@ -234,12 +457,15 @@ class OpenPLCUserManager(UserManager):
             for cert_info in self.config.security.trusted_client_certificates:
                 config_fingerprint = self._pem_to_fingerprint(cert_info["pem"])
                 if config_fingerprint and client_fingerprint == config_fingerprint:
-                    log_info(f"Certificate matched: {cert_info['id']} "
-                             f"(fingerprint: {client_fingerprint[:16]}...)")
+                    log_info(
+                        f"Certificate matched: {cert_info['id']} "
+                        f"(fingerprint: {client_fingerprint[:16]}...)"
+                    )
                     return cert_info["id"]
 
-            log_warn(f"Certificate not found in trusted list "
-                     f"(fingerprint: {client_fingerprint[:16]}...)")
+            log_warn(
+                f"Certificate not found in trusted list (fingerprint: {client_fingerprint[:16]}...)"
+            )
         except Exception as e:
             log_error(f"Certificate fingerprint extraction failed: {e}")
 
@@ -256,10 +482,10 @@ class OpenPLCUserManager(UserManager):
             Fingerprint string (colon-separated hex) or None
         """
         try:
-            if hasattr(certificate, 'der'):
+            if hasattr(certificate, "der"):
                 # Certificate object with der attribute
                 cert_der = certificate.der
-            elif hasattr(certificate, 'data'):
+            elif hasattr(certificate, "data"):
                 # Certificate object with data attribute
                 cert_der = certificate.data
             elif isinstance(certificate, bytes):
@@ -270,11 +496,10 @@ class OpenPLCUserManager(UserManager):
                 cert_str = str(certificate)
                 if "-----BEGIN CERTIFICATE-----" in cert_str:
                     # PEM format - extract base64 content
-                    cert_lines = cert_str.split('\n')
-                    cert_b64 = ''.join([
-                        line for line in cert_lines
-                        if not line.startswith('-----')
-                    ])
+                    cert_lines = cert_str.split("\n")
+                    cert_b64 = "".join(
+                        [line for line in cert_lines if not line.startswith("-----")]
+                    )
                     cert_der = base64.b64decode(cert_b64)
                 else:
                     log_warn(f"Unknown certificate format: {type(certificate)}")
@@ -282,7 +507,7 @@ class OpenPLCUserManager(UserManager):
 
             # Calculate SHA256 fingerprint
             fingerprint = hashlib.sha256(cert_der).hexdigest().upper()
-            return ':'.join(fingerprint[i:i+2] for i in range(0, len(fingerprint), 2))
+            return ":".join(fingerprint[i : i + 2] for i in range(0, len(fingerprint), 2))
         except Exception as e:
             log_error(f"Failed to extract certificate fingerprint: {e}")
             return None
@@ -299,25 +524,19 @@ class OpenPLCUserManager(UserManager):
         """
         try:
             # Extract base64 content from PEM
-            pem_lines = pem_str.strip().split('\n')
-            cert_b64 = ''.join([
-                line for line in pem_lines
-                if not line.startswith('-----')
-            ])
+            pem_lines = pem_str.strip().split("\n")
+            cert_b64 = "".join([line for line in pem_lines if not line.startswith("-----")])
             cert_der = base64.b64decode(cert_b64)
 
             # Calculate SHA256 fingerprint
             fingerprint = hashlib.sha256(cert_der).hexdigest().upper()
-            return ':'.join(fingerprint[i:i+2] for i in range(0, len(fingerprint), 2))
+            return ":".join(fingerprint[i : i + 2] for i in range(0, len(fingerprint), 2))
         except Exception as e:
             log_error(f"Failed to convert PEM to fingerprint: {e}")
             return None
 
     def _detect_auth_method(
-        self,
-        username: Optional[str],
-        password: Optional[str],
-        certificate: Optional[Any]
+        self, username: Optional[str], password: Optional[str], certificate: Optional[Any]
     ) -> str:
         """
         Detect which authentication method is being used.

--- a/docs/opcua/OPCUA_AUTHENTICATION_REVIEW.md
+++ b/docs/opcua/OPCUA_AUTHENTICATION_REVIEW.md
@@ -1,0 +1,182 @@
+# OPC-UA Plugin Authentication Implementation Report
+
+**Date:** 2026-01-22
+**Branch:** RTOP-100-OPC-UA
+**asyncua Version:** 1.1.8
+
+## Executive Summary
+
+The OpenPLC OPC-UA plugin's username/password authentication implementation **is correctly aligned with asyncua 1.1.8 patterns**. The implementation follows the recommended approach from the asyncua library documentation and community examples.
+
+---
+
+## Comparison Table: OpenPLC vs asyncua 1.1.8
+
+| Aspect | asyncua 1.1.8 Pattern | OpenPLC Implementation | Status |
+|--------|----------------------|------------------------|--------|
+| **UserManager Interface** | Extends `UserManager` base class | `OpenPLCUserManager(UserManager)` | Correct |
+| **get_user signature** | `get_user(self, iserver, username=None, password=None, certificate=None)` | Exact same signature at `user_manager.py:88-94` | Correct |
+| **Return value** | `User` object with `role` attribute, or `None` | Returns user object with `role` (UserRole enum) or `None` | Correct |
+| **Server integration** | `Server(user_manager=UserManager())` | `Server(user_manager=self.user_manager)` at `server.py:188` | Correct |
+| **UserRole enum** | `from asyncua.server.user_managers import UserRole` | Same import at `user_manager.py:15` | Correct |
+| **Password storage** | No specific requirement | bcrypt hashes (industry standard) | Good |
+
+---
+
+## Detailed Analysis
+
+### 1. UserManager Class Implementation (`user_manager.py`)
+
+**Correct Implementation:**
+```python
+# Line 15: Correct import from asyncua
+from asyncua.server.user_managers import UserManager, UserRole
+
+# Line 41: Proper inheritance
+class OpenPLCUserManager(UserManager):
+    ...
+
+# Lines 88-94: Correct method signature
+def get_user(
+    self,
+    iserver,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    certificate: Optional[Any] = None
+) -> Optional[Any]:
+```
+
+This matches the asyncua documentation exactly:
+```python
+# asyncua pattern:
+class UserManager:
+    def get_user(self, iserver, username=None, password=None, certificate=None):
+        raise NotImplementedError
+```
+
+### 2. Server Integration (`server.py:188`)
+
+**Correct Implementation:**
+```python
+# Line 188: Passes user_manager to Server constructor
+self.server = Server(user_manager=self.user_manager)
+```
+
+This aligns with asyncua's recommended pattern:
+```python
+# asyncua documentation:
+server = Server(user_manager=UserManager())
+```
+
+### 3. Role Mapping (`user_manager.py:56-61`)
+
+**Implementation:**
+```python
+ROLE_MAPPING = {
+    "viewer": UserRole.User,      # Read-only access
+    "operator": UserRole.User,    # Read/write via callbacks
+    "engineer": UserRole.Admin    # Full access
+}
+```
+
+This is consistent with asyncua's `UserRole` enum which has `User` and `Admin` levels.
+
+### 4. Password Validation (`user_manager.py:369-389`)
+
+**Strengths:**
+- Uses bcrypt for password hashing (industry standard)
+- Fails securely if bcrypt is unavailable
+- No plaintext password storage
+
+**Implementation:**
+```python
+def _validate_password(self, password: str, password_hash: str) -> bool:
+    if _bcrypt_available:
+        try:
+            return bcrypt.checkpw(password.encode(), password_hash.encode())
+        except Exception as e:
+            log_error(f"bcrypt validation error: {e}")
+            return False
+    else:
+        log_error("bcrypt not available - password authentication disabled for security")
+        return False
+```
+
+---
+
+## Minor Observations (Not Issues)
+
+| Item | Current State | asyncua Default | Impact |
+|------|--------------|-----------------|--------|
+| User return type | `SimpleNamespace` / config `User` | `User` from `asyncua.crypto.permission_rules` | Works correctly - asyncua only checks for `role` attribute |
+| Anonymous users | `SimpleNamespace()` with `role` | `User(role=UserRole.User)` | Functionally equivalent |
+
+The implementation returns user objects that have the required `role` attribute, which is all asyncua needs for authorization decisions.
+
+---
+
+## Test Coverage Gap
+
+**Finding:** No unit tests exist for the `OpenPLCUserManager` class.
+
+**Recommendation:** Consider adding tests for:
+- Password authentication success/failure
+- Certificate authentication success/failure
+- Anonymous authentication with profile restrictions
+- Role mapping verification
+
+---
+
+## Configuration Validation
+
+The current config file (`opcua.json`) shows proper usage:
+
+```json
+{
+  "users": [
+    {
+      "type": "certificate",
+      "certificate_id": "engineer_cert",
+      "role": "engineer"
+    },
+    {
+      "type": "password",
+      "username": "operator",
+      "password_hash": "$2b$10$Y/WT4Z8ku9hObwSPk1bmY...",
+      "role": "operator"
+    }
+  ]
+}
+```
+
+---
+
+## Conclusion
+
+**The implementation is healthy and correctly follows asyncua 1.1.8 patterns.**
+
+No changes are required for core functionality. The implementation:
+1. Uses the correct `UserManager` interface
+2. Has the correct `get_user()` signature
+3. Integrates properly with asyncua `Server`
+4. Uses appropriate security practices (bcrypt hashing)
+
+---
+
+## Optional Improvements (Not Required)
+
+| Priority | Improvement | Rationale |
+|----------|-------------|-----------|
+| Low | Add unit tests for `OpenPLCUserManager` | Increase confidence in auth logic |
+| Low | Return asyncua's `User` class directly | Closer adherence to asyncua patterns (not required for functionality) |
+| Low | Add rate limiting on auth attempts | Security hardening against brute force |
+
+---
+
+## References
+
+- [Server set User with Password - GitHub Discussion #1386](https://github.com/FreeOpcUa/opcua-asyncio/discussions/1386)
+- [Server with Authentication (user/password) and Encryption - GitHub Discussion #934](https://github.com/FreeOpcUa/opcua-asyncio/discussions/934)
+- [asyncua PyPI](https://pypi.org/project/asyncua/)
+- [asyncua server.py](https://github.com/FreeOpcUa/opcua-asyncio/blob/master/asyncua/server/server.py)
+- [asyncua server-with-encryption.py example](https://github.com/FreeOpcUa/opcua-asyncio/blob/master/examples/server-with-encryption.py)

--- a/docs/opcua/OPCUA_SECURITY_MODE_INSUFFICIENT_ANALYSIS.md
+++ b/docs/opcua/OPCUA_SECURITY_MODE_INSUFFICIENT_ANALYSIS.md
@@ -1,0 +1,146 @@
+# OPC-UA BadSecurityModeInsufficient Error Analysis
+
+**Date:** 2026-01-22
+**Context:** Username/password authentication over insecure (unencrypted) endpoint
+
+## Summary
+
+When using only the insecure security profile with Username authentication, OPC-UA clients display the error:
+
+> Error 'BadSecurityModeInsufficient' was returned during ActivateSession, press 'Ignore' to suppress the error and continue connecting. If you ignore the error it is possible that the password is being sent in clear text.
+
+This is **NOT a bug** - it's a security feature defined in the OPC-UA specification.
+
+---
+
+## What's Happening
+
+This error is a **security feature** defined in the OPC-UA specification (Part 4, Section 7.36).
+
+**The error comes from the OPC-UA client** (like UAExpert), not the server. When you configure:
+- Security Policy: `None`
+- Security Mode: `None`
+- Auth Method: `Username` (password authentication)
+
+The client detects that it would send the password **in plain text** over the network and warns the user. This is intentional behavior to protect against accidentally exposing credentials.
+
+---
+
+## OPC-UA Security Architecture
+
+OPC-UA has **two separate security layers**:
+
+| Layer | Purpose | Description |
+|-------|---------|-------------|
+| **Channel Security** | Encrypts communication between client/server | Configured via `security_policy` and `security_mode` |
+| **Token Security** | Can encrypt user credentials separately | Can have its own SecurityPolicyUri |
+
+When both are "None", passwords travel unencrypted over the network.
+
+### Security Policy Options
+
+| Policy | Mode | Result |
+|--------|------|--------|
+| `None` | `None` | No encryption (plaintext) |
+| `Basic256Sha256` | `Sign` | Messages are signed (integrity) |
+| `Basic256Sha256` | `SignAndEncrypt` | Full encryption (confidentiality + integrity) |
+
+---
+
+## Configuration Options
+
+### Option 1: Use Encrypted Security Profile (Recommended)
+
+Keep the `SignAndEncrypt` profile enabled alongside the insecure one:
+
+```json
+"security_profiles": [
+  {
+    "name": "insecure",
+    "enabled": true,
+    "security_policy": "None",
+    "security_mode": "None",
+    "auth_methods": ["Anonymous"]
+  },
+  {
+    "name": "SignAndEncrypt",
+    "enabled": true,
+    "security_policy": "Basic256Sha256",
+    "security_mode": "SignAndEncrypt",
+    "auth_methods": ["Username", "Certificate"]
+  }
+]
+```
+
+This configuration:
+- Allows Anonymous access on the insecure endpoint
+- Requires encryption for Username/password authentication
+- Follows OPC-UA security best practices
+
+### Option 2: Accept the Risk (Click "Ignore")
+
+If you're on a trusted local network (like a lab environment), clicking "Ignore" in the OPC-UA client will:
+- Send the password in plaintext
+- Connection will work normally
+- **Only use this in isolated/trusted networks**
+
+**Warning:** This exposes credentials to network sniffing attacks.
+
+### Option 3: Token-Level Encryption (Advanced)
+
+OPC-UA allows the UserIdentityToken to have its own security policy, even when channel security is "None". This means you could theoretically:
+- Use `None` for channel security (no message encryption)
+- Use `Basic256Sha256` for token security (password is encrypted)
+
+This requires additional configuration in asyncua and is not currently implemented.
+
+---
+
+## Recommendations
+
+| Environment | Recommendation |
+|-------------|----------------|
+| **Production / Industrial** | Use Option 1 - require encryption for password auth |
+| **Development / Testing** | Option 2 is acceptable on isolated networks |
+| **Internet-facing** | Always use SignAndEncrypt with certificates |
+
+---
+
+## Technical Details
+
+### Error Code
+
+- **Status Code:** `BadSecurityModeInsufficient` (0x80E60000)
+- **Meaning:** "The operation is not permitted over the current secure channel"
+
+### Where the Check Occurs
+
+The security check happens during the `ActivateSession` phase:
+1. Client connects to server (OpenSecureChannel)
+2. Client creates session (CreateSession)
+3. Client activates session with credentials (ActivateSession) - **Error occurs here**
+
+The client library checks if sending credentials over the current security mode is safe before transmitting.
+
+### asyncua Behavior
+
+The asyncua library includes logic to:
+1. Warn when creating open endpoints alongside encrypted ones
+2. Try to find an encrypting policy for password transmission
+3. Log warnings when no encrypting policy is available
+
+From `asyncua/server/server.py`:
+```python
+# try to avoid plaintext password, find first policy with encryption
+# ...
+# No encrypting policy available, password may get transferred in plaintext
+```
+
+---
+
+## References
+
+- [OPC UA Part 4: Services - 7.37 UserTokenPolicy](https://reference.opcfoundation.org/Core/Part4/v104/docs/7.37)
+- [Server with Authentication (user/password) and Encryption - GitHub Discussion #934](https://github.com/FreeOpcUa/opcua-asyncio/discussions/934)
+- [Server set User with Password - GitHub Discussion #1386](https://github.com/FreeOpcUa/opcua-asyncio/discussions/1386)
+- [asyncua PyPI](https://pypi.org/project/asyncua/)

--- a/tests/pytest/plugins/opcua/test_user_manager.py
+++ b/tests/pytest/plugins/opcua/test_user_manager.py
@@ -1,0 +1,681 @@
+"""
+Unit tests for OPC-UA User Manager.
+
+Tests cover:
+- Password authentication success/failure
+- Certificate authentication success/failure
+- Anonymous authentication with profile restrictions
+- Role mapping verification
+- Rate limiting / brute-force protection
+"""
+
+import time
+from dataclasses import dataclass
+from typing import List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+from asyncua.crypto.permission_rules import User
+from asyncua.server.user_managers import UserRole
+
+# Import after path setup in conftest
+from user_manager import (
+    DEFAULT_ATTEMPT_WINDOW_SECONDS,
+    DEFAULT_LOCKOUT_DURATION_SECONDS,
+    DEFAULT_MAX_ATTEMPTS,
+    OpenPLCUserManager,
+    RateLimitConfig,
+    RateLimiter,
+)
+
+# ============================================================================
+# Mock Configuration Classes
+# ============================================================================
+
+
+@dataclass
+class MockSecurityProfile:
+    """Mock security profile for testing."""
+
+    name: str
+    enabled: bool
+    security_policy: str
+    security_mode: str
+    auth_methods: List[str]
+
+
+@dataclass
+class MockUser:
+    """Mock user configuration."""
+
+    type: str
+    username: Optional[str]
+    password_hash: Optional[str]
+    certificate_id: Optional[str]
+    role: str
+
+
+@dataclass
+class MockServerConfig:
+    """Mock server configuration."""
+
+    security_profiles: List[MockSecurityProfile]
+
+
+@dataclass
+class MockSecurityConfig:
+    """Mock security configuration."""
+
+    trusted_client_certificates: List[dict]
+
+
+@dataclass
+class MockOpcuaConfig:
+    """Mock OpcuaConfig for testing."""
+
+    server: MockServerConfig
+    security: MockSecurityConfig
+    users: List[MockUser]
+
+
+def create_test_config(
+    users: Optional[List[MockUser]] = None,
+    profiles: Optional[List[MockSecurityProfile]] = None,
+    trusted_certs: Optional[List[dict]] = None,
+) -> MockOpcuaConfig:
+    """Create a mock config for testing."""
+    if users is None:
+        users = []
+    if profiles is None:
+        profiles = [
+            MockSecurityProfile(
+                name="insecure",
+                enabled=True,
+                security_policy="None",
+                security_mode="None",
+                auth_methods=["Username", "Anonymous"],
+            )
+        ]
+    if trusted_certs is None:
+        trusted_certs = []
+
+    return MockOpcuaConfig(
+        server=MockServerConfig(security_profiles=profiles),
+        security=MockSecurityConfig(trusted_client_certificates=trusted_certs),
+        users=users,
+    )
+
+
+# ============================================================================
+# Rate Limiter Tests
+# ============================================================================
+
+
+class TestRateLimiter:
+    """Tests for the RateLimiter class."""
+
+    def test_init_default_config(self):
+        """Test RateLimiter initializes with default config."""
+        limiter = RateLimiter()
+        assert limiter.config.max_attempts == DEFAULT_MAX_ATTEMPTS
+        assert limiter.config.lockout_duration_seconds == DEFAULT_LOCKOUT_DURATION_SECONDS
+        assert limiter.config.attempt_window_seconds == DEFAULT_ATTEMPT_WINDOW_SECONDS
+
+    def test_init_custom_config(self):
+        """Test RateLimiter initializes with custom config."""
+        config = RateLimitConfig(
+            max_attempts=3, lockout_duration_seconds=60, attempt_window_seconds=30
+        )
+        limiter = RateLimiter(config)
+        assert limiter.config.max_attempts == 3
+        assert limiter.config.lockout_duration_seconds == 60
+        assert limiter.config.attempt_window_seconds == 30
+
+    def test_not_locked_out_initially(self):
+        """Test that new identifiers are not locked out."""
+        limiter = RateLimiter()
+        assert limiter.is_locked_out("user:test") is False
+
+    def test_lockout_after_max_attempts(self):
+        """Test lockout is triggered after max failed attempts."""
+        config = RateLimitConfig(max_attempts=3, lockout_duration_seconds=60)
+        limiter = RateLimiter(config)
+
+        identifier = "user:attacker"
+
+        # Record failed attempts up to max
+        for i in range(3):
+            assert limiter.is_locked_out(identifier) is False
+            limiter.record_attempt(identifier, success=False)
+
+        # Should now be locked out
+        assert limiter.is_locked_out(identifier) is True
+
+    def test_successful_auth_resets_tracker(self):
+        """Test that successful auth resets the attempt counter."""
+        config = RateLimitConfig(max_attempts=3)
+        limiter = RateLimiter(config)
+
+        identifier = "user:test"
+
+        # Record some failed attempts
+        limiter.record_attempt(identifier, success=False)
+        limiter.record_attempt(identifier, success=False)
+
+        # Successful auth
+        limiter.record_attempt(identifier, success=True)
+
+        # Should not be locked out
+        assert limiter.is_locked_out(identifier) is False
+
+        # Should be able to fail again without immediate lockout
+        limiter.record_attempt(identifier, success=False)
+        assert limiter.is_locked_out(identifier) is False
+
+    def test_lockout_remaining_time(self):
+        """Test getting remaining lockout time."""
+        config = RateLimitConfig(max_attempts=1, lockout_duration_seconds=10)
+        limiter = RateLimiter(config)
+
+        identifier = "user:test"
+
+        # Not locked out initially
+        assert limiter.get_lockout_remaining(identifier) == 0.0
+
+        # Trigger lockout
+        limiter.record_attempt(identifier, success=False)
+
+        # Should have remaining time
+        remaining = limiter.get_lockout_remaining(identifier)
+        assert 9 <= remaining <= 10
+
+    def test_lockout_expires(self):
+        """Test that lockout expires after duration."""
+        config = RateLimitConfig(
+            max_attempts=1,
+            lockout_duration_seconds=0.1,  # 100ms for fast test
+        )
+        limiter = RateLimiter(config)
+
+        identifier = "user:test"
+
+        # Trigger lockout
+        limiter.record_attempt(identifier, success=False)
+        assert limiter.is_locked_out(identifier) is True
+
+        # Wait for lockout to expire
+        time.sleep(0.15)
+
+        # Should no longer be locked out
+        assert limiter.is_locked_out(identifier) is False
+
+    def test_attempt_window_reset(self):
+        """Test that attempt count resets after window expires."""
+        config = RateLimitConfig(max_attempts=3, attempt_window_seconds=0.1)  # 100ms window
+        limiter = RateLimiter(config)
+
+        identifier = "user:test"
+
+        # Record 2 failed attempts
+        limiter.record_attempt(identifier, success=False)
+        limiter.record_attempt(identifier, success=False)
+
+        # Wait for window to expire
+        time.sleep(0.15)
+
+        # Record more attempts - should reset count
+        limiter.record_attempt(identifier, success=False)
+        limiter.record_attempt(identifier, success=False)
+
+        # Should not be locked out (only 2 attempts in new window)
+        assert limiter.is_locked_out(identifier) is False
+
+    def test_cleanup_expired(self):
+        """Test cleanup of expired trackers."""
+        config = RateLimitConfig(
+            max_attempts=1, lockout_duration_seconds=0.05, attempt_window_seconds=0.05
+        )
+        limiter = RateLimiter(config)
+
+        # Create some trackers
+        limiter.record_attempt("user:a", success=False)
+        limiter.record_attempt("user:b", success=False)
+
+        # Wait for expiration
+        time.sleep(0.1)
+
+        # Cleanup should remove expired entries
+        removed = limiter.cleanup_expired()
+        assert removed == 2
+        assert len(limiter._trackers) == 0
+
+
+# ============================================================================
+# OpenPLCUserManager Tests
+# ============================================================================
+
+
+class TestOpenPLCUserManager:
+    """Tests for the OpenPLCUserManager class."""
+
+    def test_init_with_password_users(self):
+        """Test initialization with password users."""
+        users = [
+            MockUser(
+                type="password",
+                username="operator",
+                password_hash="$2b$10$hash",
+                certificate_id=None,
+                role="operator",
+            ),
+            MockUser(
+                type="password",
+                username="engineer",
+                password_hash="$2b$10$hash2",
+                certificate_id=None,
+                role="engineer",
+            ),
+        ]
+        config = create_test_config(users=users)
+
+        manager = OpenPLCUserManager(config)
+
+        assert len(manager.users) == 2
+        assert "operator" in manager.users
+        assert "engineer" in manager.users
+        assert manager._user_roles["operator"] == "operator"
+        assert manager._user_roles["engineer"] == "engineer"
+
+    def test_init_with_certificate_users(self):
+        """Test initialization with certificate users."""
+        users = [
+            MockUser(
+                type="certificate",
+                username=None,
+                password_hash=None,
+                certificate_id="cert1",
+                role="engineer",
+            ),
+        ]
+        config = create_test_config(users=users)
+
+        manager = OpenPLCUserManager(config)
+
+        assert len(manager.cert_users) == 1
+        assert "cert1" in manager.cert_users
+        assert manager._user_roles["cert:cert1"] == "engineer"
+
+    def test_init_with_rate_limit_config(self):
+        """Test initialization with custom rate limit config."""
+        config = create_test_config()
+        rate_config = RateLimitConfig(max_attempts=10)
+
+        manager = OpenPLCUserManager(config, rate_limit_config=rate_config)
+
+        assert manager.rate_limiter.config.max_attempts == 10
+
+
+class TestPasswordAuthentication:
+    """Tests for password authentication."""
+
+    @pytest.fixture
+    def manager_with_user(self):
+        """Create manager with a test user."""
+        # BCrypt hash for "testpass123"
+        password_hash = "$2b$10$rJrPxLxGxNzVzqZqxZqZqO1234567890123456789012345678901234"
+
+        users = [
+            MockUser(
+                type="password",
+                username="testuser",
+                password_hash=password_hash,
+                certificate_id=None,
+                role="operator",
+            ),
+        ]
+        profiles = [
+            MockSecurityProfile(
+                name="test",
+                enabled=True,
+                security_policy="None",
+                security_mode="None",
+                auth_methods=["Username"],
+            )
+        ]
+        config = create_test_config(users=users, profiles=profiles)
+        return OpenPLCUserManager(config)
+
+    def test_auth_fails_user_not_found(self, manager_with_user):
+        """Test authentication fails for unknown user."""
+        user = manager_with_user.get_user(None, username="unknown", password="password")
+        assert user is None
+
+    def test_auth_fails_wrong_password(self, manager_with_user):
+        """Test authentication fails for wrong password."""
+        with patch("user_manager.bcrypt") as mock_bcrypt:
+            mock_bcrypt.checkpw.return_value = False
+
+            user = manager_with_user.get_user(None, username="testuser", password="wrongpass")
+            assert user is None
+
+    def test_auth_success_returns_user_object(self, manager_with_user):
+        """Test successful authentication returns asyncua User object."""
+        with patch("user_manager.bcrypt") as mock_bcrypt:
+            mock_bcrypt.checkpw.return_value = True
+
+            user = manager_with_user.get_user(None, username="testuser", password="testpass123")
+
+            assert user is not None
+            assert isinstance(user, User)
+            assert user.name == "testuser"
+            assert user.role == UserRole.User  # operator maps to User
+            assert user.openplc_role == "operator"
+
+    def test_engineer_role_maps_to_admin(self):
+        """Test engineer role maps to UserRole.Admin."""
+        password_hash = "$2b$10$test"
+
+        users = [
+            MockUser(
+                type="password",
+                username="admin",
+                password_hash=password_hash,
+                certificate_id=None,
+                role="engineer",
+            ),
+        ]
+        profiles = [
+            MockSecurityProfile(
+                name="test",
+                enabled=True,
+                security_policy="None",
+                security_mode="None",
+                auth_methods=["Username"],
+            )
+        ]
+        config = create_test_config(users=users, profiles=profiles)
+        manager = OpenPLCUserManager(config)
+
+        with patch("user_manager.bcrypt") as mock_bcrypt:
+            mock_bcrypt.checkpw.return_value = True
+
+            user = manager.get_user(None, username="admin", password="pass")
+
+            assert user is not None
+            assert user.role == UserRole.Admin
+            assert user.openplc_role == "engineer"
+
+
+class TestAnonymousAuthentication:
+    """Tests for anonymous authentication."""
+
+    def test_anonymous_allowed_when_profile_supports(self):
+        """Test anonymous auth succeeds when profile allows it."""
+        profiles = [
+            MockSecurityProfile(
+                name="insecure",
+                enabled=True,
+                security_policy="None",
+                security_mode="None",
+                auth_methods=["Anonymous"],
+            )
+        ]
+        config = create_test_config(profiles=profiles)
+        manager = OpenPLCUserManager(config)
+
+        user = manager.get_user(None)  # No credentials = anonymous
+
+        assert user is not None
+        assert isinstance(user, User)
+        assert user.name == "anonymous"
+        assert user.role == UserRole.User
+        assert user.openplc_role == "viewer"
+
+    def test_anonymous_denied_when_profile_disallows(self):
+        """Test anonymous auth fails when profile doesn't allow it."""
+        profiles = [
+            MockSecurityProfile(
+                name="secure",
+                enabled=True,
+                security_policy="Basic256Sha256",
+                security_mode="SignAndEncrypt",
+                auth_methods=["Username", "Certificate"],  # No Anonymous
+            )
+        ]
+        config = create_test_config(profiles=profiles)
+        manager = OpenPLCUserManager(config)
+
+        user = manager.get_user(None)  # No credentials = anonymous
+
+        assert user is None
+
+
+class TestRateLimitingIntegration:
+    """Tests for rate limiting in authentication."""
+
+    def test_lockout_blocks_authentication(self):
+        """Test that locked out users cannot authenticate."""
+        password_hash = "$2b$10$test"
+
+        users = [
+            MockUser(
+                type="password",
+                username="testuser",
+                password_hash=password_hash,
+                certificate_id=None,
+                role="operator",
+            ),
+        ]
+        profiles = [
+            MockSecurityProfile(
+                name="test",
+                enabled=True,
+                security_policy="None",
+                security_mode="None",
+                auth_methods=["Username"],
+            )
+        ]
+        config = create_test_config(users=users, profiles=profiles)
+
+        # Use low max_attempts for testing
+        rate_config = RateLimitConfig(max_attempts=2, lockout_duration_seconds=60)
+        manager = OpenPLCUserManager(config, rate_limit_config=rate_config)
+
+        with patch("user_manager.bcrypt") as mock_bcrypt:
+            mock_bcrypt.checkpw.return_value = False
+
+            # First two attempts should fail but not lock out
+            manager.get_user(None, username="testuser", password="wrong")
+            result = manager.get_user(None, username="testuser", password="wrong")
+            assert result is None
+
+            # Third attempt should be blocked by rate limiting
+            mock_bcrypt.checkpw.return_value = True  # Even correct password
+            result = manager.get_user(None, username="testuser", password="correct")
+            assert result is None  # Blocked by lockout
+
+    def test_successful_auth_resets_rate_limit(self):
+        """Test successful authentication resets rate limit counter."""
+        password_hash = "$2b$10$test"
+
+        users = [
+            MockUser(
+                type="password",
+                username="testuser",
+                password_hash=password_hash,
+                certificate_id=None,
+                role="operator",
+            ),
+        ]
+        profiles = [
+            MockSecurityProfile(
+                name="test",
+                enabled=True,
+                security_policy="None",
+                security_mode="None",
+                auth_methods=["Username"],
+            )
+        ]
+        config = create_test_config(users=users, profiles=profiles)
+
+        rate_config = RateLimitConfig(max_attempts=3)
+        manager = OpenPLCUserManager(config, rate_limit_config=rate_config)
+
+        with patch("user_manager.bcrypt") as mock_bcrypt:
+            # Two failed attempts
+            mock_bcrypt.checkpw.return_value = False
+            manager.get_user(None, username="testuser", password="wrong")
+            manager.get_user(None, username="testuser", password="wrong")
+
+            # Successful auth
+            mock_bcrypt.checkpw.return_value = True
+            result = manager.get_user(None, username="testuser", password="correct")
+            assert result is not None
+
+            # Should be able to fail again without lockout
+            mock_bcrypt.checkpw.return_value = False
+            manager.get_user(None, username="testuser", password="wrong")
+            manager.get_user(None, username="testuser", password="wrong")
+
+            # Still not locked out (counter was reset)
+            mock_bcrypt.checkpw.return_value = True
+            result = manager.get_user(None, username="testuser", password="correct")
+            assert result is not None
+
+
+class TestAuthMethodDetection:
+    """Tests for authentication method detection."""
+
+    def test_detect_username_method(self):
+        """Test detection of username/password method."""
+        config = create_test_config()
+        manager = OpenPLCUserManager(config)
+
+        method = manager._detect_auth_method("user", "pass", None)
+        assert method == "Username"
+
+    def test_detect_certificate_method(self):
+        """Test detection of certificate method."""
+        config = create_test_config()
+        manager = OpenPLCUserManager(config)
+
+        mock_cert = MagicMock()
+        method = manager._detect_auth_method(None, None, mock_cert)
+        assert method == "Certificate"
+
+    def test_detect_anonymous_method(self):
+        """Test detection of anonymous method."""
+        config = create_test_config()
+        manager = OpenPLCUserManager(config)
+
+        method = manager._detect_auth_method(None, None, None)
+        assert method == "Anonymous"
+
+    def test_username_takes_precedence_over_certificate(self):
+        """Test that username/password takes precedence over certificate."""
+        config = create_test_config()
+        manager = OpenPLCUserManager(config)
+
+        mock_cert = MagicMock()
+        method = manager._detect_auth_method("user", "pass", mock_cert)
+        assert method == "Username"
+
+
+class TestRoleMappings:
+    """Tests for role mapping."""
+
+    def test_viewer_maps_to_user(self):
+        """Test viewer role maps to UserRole.User."""
+        assert OpenPLCUserManager.ROLE_MAPPING["viewer"] == UserRole.User
+
+    def test_operator_maps_to_user(self):
+        """Test operator role maps to UserRole.User."""
+        assert OpenPLCUserManager.ROLE_MAPPING["operator"] == UserRole.User
+
+    def test_engineer_maps_to_admin(self):
+        """Test engineer role maps to UserRole.Admin."""
+        assert OpenPLCUserManager.ROLE_MAPPING["engineer"] == UserRole.Admin
+
+
+class TestProfileMatching:
+    """Tests for security profile matching."""
+
+    def test_finds_enabled_profile(self):
+        """Test finding an enabled profile that supports auth method."""
+        profiles = [
+            MockSecurityProfile(
+                name="disabled",
+                enabled=False,
+                security_policy="None",
+                security_mode="None",
+                auth_methods=["Username"],
+            ),
+            MockSecurityProfile(
+                name="enabled",
+                enabled=True,
+                security_policy="None",
+                security_mode="None",
+                auth_methods=["Username"],
+            ),
+        ]
+        config = create_test_config(profiles=profiles)
+        manager = OpenPLCUserManager(config)
+
+        profile = manager._find_profile_by_auth_method("Username")
+
+        assert profile is not None
+        assert profile.name == "enabled"
+
+    def test_returns_none_when_no_matching_profile(self):
+        """Test returns None when no profile supports auth method."""
+        profiles = [
+            MockSecurityProfile(
+                name="cert_only",
+                enabled=True,
+                security_policy="Basic256Sha256",
+                security_mode="SignAndEncrypt",
+                auth_methods=["Certificate"],
+            ),
+        ]
+        config = create_test_config(profiles=profiles)
+        manager = OpenPLCUserManager(config)
+
+        profile = manager._find_profile_by_auth_method("Username")
+
+        assert profile is None
+
+
+class TestRateLimitIdentifier:
+    """Tests for rate limit identifier generation."""
+
+    def test_identifier_for_username(self):
+        """Test identifier generation for username auth."""
+        config = create_test_config()
+        manager = OpenPLCUserManager(config)
+
+        identifier = manager._get_rate_limit_identifier("testuser", None)
+        assert identifier == "user:testuser"
+
+    def test_identifier_for_certificate(self):
+        """Test identifier generation for certificate auth."""
+        config = create_test_config()
+        manager = OpenPLCUserManager(config)
+
+        # Mock certificate with bytes data
+        mock_cert = b"certificate_data"
+
+        with patch.object(manager, "_cert_to_fingerprint") as mock_fp:
+            mock_fp.return_value = "AB:CD:EF:12:34:56:78:90:AB:CD:EF:12:34:56:78:90"
+
+            identifier = manager._get_rate_limit_identifier(None, mock_cert)
+
+            assert identifier is not None
+            assert identifier.startswith("cert:")
+
+    def test_identifier_none_for_anonymous(self):
+        """Test no identifier for anonymous auth."""
+        config = create_test_config()
+        manager = OpenPLCUserManager(config)
+
+        identifier = manager._get_rate_limit_identifier(None, None)
+        assert identifier is None


### PR DESCRIPTION
## Summary

- Implement rate limiting for authentication attempts to protect against brute-force attacks
- Update user_manager.py to return asyncua's native `User` class for better library integration
- Add comprehensive unit tests for the OpenPLCUserManager class
- Add documentation for authentication implementation and security mode analysis

## Changes

### Brute-Force Protection (`user_manager.py`)
- Added `RateLimiter` class with configurable settings:
  - `max_attempts`: 5 (default) failed attempts before lockout
  - `lockout_duration_seconds`: 300 (5 minutes) lockout period
  - `attempt_window_seconds`: 60 (1 minute) window for counting attempts
- Rate limiting tracks by username (`user:{username}`) or certificate fingerprint (`cert:{fingerprint}`)
- Successful authentication resets the attempt counter
- Anonymous authentication is not rate limited

### asyncua User Class Integration
- Now returns `asyncua.crypto.permission_rules.User` objects instead of `SimpleNamespace`
- Preserves `openplc_role` attribute for permission callbacks
- Cleaner integration with asyncua's authorization system

### Unit Tests (`test_user_manager.py`)
- 32 new tests covering:
  - RateLimiter functionality (9 tests)
  - OpenPLCUserManager initialization (3 tests)
  - Password authentication (4 tests)
  - Anonymous authentication (2 tests)
  - Rate limiting integration (2 tests)
  - Auth method detection (4 tests)
  - Role mappings (3 tests)
  - Profile matching (2 tests)
  - Rate limit identifier generation (3 tests)

### Documentation
- `OPCUA_AUTHENTICATION_REVIEW.md`: Comparison with asyncua 1.1.8 patterns
- `OPCUA_SECURITY_MODE_INSUFFICIENT_ANALYSIS.md`: Analysis of BadSecurityModeInsufficient error

## Test plan

- [x] All 32 unit tests pass (`pytest tests/pytest/plugins/opcua/test_user_manager.py`)
- [ ] Manual testing with OPC-UA client (UAExpert)
- [ ] Verify rate limiting blocks after max attempts
- [ ] Verify successful auth resets the counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)