### PR TITLE
fix: Add recursive validation for nested OPC-UA structures

### DIFF
--- a/core/src/drivers/plugins/python/shared/plugin_config_decode/opcua_config_model.py
+++ b/core/src/drivers/plugins/python/shared/plugin_config_decode/opcua_config_model.py
@@ -482,18 +482,23 @@ class OpcuaMasterConfig(PluginConfigContract):
             def validate_field_datatypes(
                 fields: List[VariableField],
                 struct_node_id: str,
-                plugin_name: str
+                plugin_name: str,
+                path: str = ""
             ) -> None:
                 for field in fields:
+                    # Build full path for better error messages
+                    current_path = f"{path}.{field.name}" if path else field.name
                     if field.fields:
                         # Complex type with nested fields - recurse into children
                         # Don't validate the parent's datatype (e.g., TON, TOF, custom FB)
-                        validate_field_datatypes(field.fields, struct_node_id, plugin_name)
+                        validate_field_datatypes(
+                            field.fields, struct_node_id, plugin_name, current_path
+                        )
                     else:
                         # Leaf field - validate its datatype
-                        if field.datatype.upper() not in VALID_DATATYPES:
+                        if not field.datatype or field.datatype.upper() not in VALID_DATATYPES:
                             raise ValueError(
-                                f"Invalid datatype '{field.datatype}' for field '{field.name}' "
+                                f"Invalid datatype '{field.datatype}' for field '{current_path}' "
                                 f"in struct '{struct_node_id}' in plugin '{plugin_name}'. "
                                 f"Valid types: {sorted(VALID_DATATYPES)}"
                             )

--- a/core/src/drivers/plugins/python/shared/plugin_config_decode/opcua_config_model.py
+++ b/core/src/drivers/plugins/python/shared/plugin_config_decode/opcua_config_model.py
@@ -12,14 +12,25 @@ except ImportError:
 # Permission types for variables
 PermissionType = Literal["r", "w", "rw"]
 
-# Valid datatypes for OPC-UA variables
+# Valid datatypes for OPC-UA variables (IEC 61131-3 base types)
+# This list must match the base types supported by openplc-editor
 VALID_DATATYPES = frozenset([
-    "BOOL", "BYTE",
-    "INT", "DINT", "LINT", "INT32",
-    "FLOAT", "REAL",
+    # Boolean
+    "BOOL",
+    # Signed integers
+    "SINT", "INT", "DINT", "LINT",
+    # Unsigned integers
+    "USINT", "UINT", "UDINT", "ULINT",
+    # Floating point
+    "REAL", "LREAL",
+    # Bit strings
+    "BYTE", "WORD", "DWORD", "LWORD",
+    # String
     "STRING",
-    # TIME-related types (IEC 61131-3)
+    # Time-related types
     "TIME", "DATE", "TOD", "DT",
+    # Legacy/alternative names (for backward compatibility)
+    "INT32", "FLOAT",
 ])
 
 
@@ -466,6 +477,27 @@ class OpcuaMasterConfig(PluginConfigContract):
                 raise ValueError(f"Duplicate indices found in plugin '{plugin.name}'")
 
             # Validate datatypes
+            # Helper to validate datatypes recursively for nested fields
+            # Only leaf fields (those without nested children) are validated
+            def validate_field_datatypes(
+                fields: List[VariableField],
+                struct_node_id: str,
+                plugin_name: str
+            ) -> None:
+                for field in fields:
+                    if field.fields:
+                        # Complex type with nested fields - recurse into children
+                        # Don't validate the parent's datatype (e.g., TON, TOF, custom FB)
+                        validate_field_datatypes(field.fields, struct_node_id, plugin_name)
+                    else:
+                        # Leaf field - validate its datatype
+                        if field.datatype.upper() not in VALID_DATATYPES:
+                            raise ValueError(
+                                f"Invalid datatype '{field.datatype}' for field '{field.name}' "
+                                f"in struct '{struct_node_id}' in plugin '{plugin_name}'. "
+                                f"Valid types: {sorted(VALID_DATATYPES)}"
+                            )
+
             for var in address_space.variables:
                 if var.datatype.upper() not in VALID_DATATYPES:
                     raise ValueError(
@@ -473,13 +505,7 @@ class OpcuaMasterConfig(PluginConfigContract):
                         f"in plugin '{plugin.name}'. Valid types: {sorted(VALID_DATATYPES)}"
                     )
             for struct in address_space.structures:
-                for field in struct.fields:
-                    if field.datatype.upper() not in VALID_DATATYPES:
-                        raise ValueError(
-                            f"Invalid datatype '{field.datatype}' for field '{field.name}' "
-                            f"in struct '{struct.node_id}' in plugin '{plugin.name}'. "
-                            f"Valid types: {sorted(VALID_DATATYPES)}"
-                        )
+                validate_field_datatypes(struct.fields, struct.node_id, plugin.name)
             for arr in address_space.arrays:
                 if arr.datatype.upper() not in VALID_DATATYPES:
                     raise ValueError(


### PR DESCRIPTION
## Summary

- Fix validation error when adding Function Block instances to OPC-UA address space
- Add recursive datatype validation for nested structures
- Add missing IEC 61131-3 base types to VALID_DATATYPES

## Problem

When adding a Function Block instance (e.g., `IRRIGATION_MAIN_CONTROLLER0`) to the OPC-UA variables list, the runtime failed with:

```
Configuration validation error: Invalid datatype 'TON' for field 'TON0' in struct 'PLC.main.IRRIGATION_MAIN_CONTROLLER0' in plugin 'opcua_server'
```

The validation was checking the datatype of intermediate complex types (`TON`, `TOF`, custom FBs) instead of only validating the leaf fields.

## Root Cause

The datatype validation only checked the first level of fields:
```python
for field in struct.fields:
    if field.datatype.upper() not in VALID_DATATYPES:  # Fails on TON, TOF, etc.
```

But nested structures require recursive validation that **skips complex types** (those with nested `fields`) and only validates **leaf fields**.

## Solution

1. **Added recursive `validate_field_datatypes()`** that mirrors the existing `collect_field_indices()` pattern:
   - If a field has nested `fields` -> recurse into children (don't validate parent datatype)
   - If a field is a leaf (no nested fields) -> validate its datatype

2. **Added missing IEC 61131-3 base types** to `VALID_DATATYPES`:
   - `SINT`, `USINT`, `UINT`, `UDINT`, `ULINT` (integer types)
   - `LREAL` (double-precision float)
   - `WORD`, `DWORD`, `LWORD` (bit string types)

## Test plan

- [ ] Upload a project with FB instances in OPC-UA address space
- [ ] Verify the runtime loads without validation errors
- [ ] Verify nested FB fields (e.g., TON.ET, TON.Q) are accessible via OPC-UA
- [ ] Test with various IEC 61131-3 base types (SINT, UINT, LREAL, WORD, etc.)

---
Generated with [Claude Code](https://claude.ai/code)