### PR TITLE
feat: Add --print-debug flag to control debug log output

### DIFF
--- a/core/src/plc_app/plc_main.c
+++ b/core/src/plc_app/plc_main.c
@@ -35,18 +35,27 @@ void handle_sigint(int sig)
 
 int main(int argc, char *argv[])
 {
-    // Check for --print-logs argument
+    bool print_debug = false;
+
+    // Check for command line arguments
     for (int i = 1; i < argc; i++)
     {
         if (strcmp(argv[i], "--print-logs") == 0)
         {
             print_logs = true;
-            break;
+        }
+        if (strcmp(argv[i], "--print-debug") == 0)
+        {
+            print_debug = true;
         }
     }
 
     // Initialize logging system
-    log_set_level(LOG_LEVEL_DEBUG);
+    // Only enable debug level logging if --print-debug flag is passed
+    if (print_debug)
+    {
+        log_set_level(LOG_LEVEL_DEBUG);
+    }
 
     if (log_init(LOG_SOCKET_PATH) < 0)
     {

--- a/core/src/plc_app/plc_main.c
+++ b/core/src/plc_app/plc_main.c
@@ -44,9 +44,15 @@ int main(int argc, char *argv[])
         {
             print_logs = true;
         }
-        if (strcmp(argv[i], "--print-debug") == 0)
+        else if (strcmp(argv[i], "--print-debug") == 0)
         {
             print_debug = true;
+        }
+
+        // Early exit if both flags are found
+        if (print_logs && print_debug)
+        {
+            break;
         }
     }
 

--- a/start_openplc.sh
+++ b/start_openplc.sh
@@ -206,5 +206,13 @@ setup_plugin_venvs() {
 setup_plugin_venvs
 setup_runtime_venv
 
+# Parse command line arguments
+PRINT_DEBUG=""
+for arg in "$@"; do
+    if [ "$arg" = "--print-debug" ]; then
+        PRINT_DEBUG="--print-debug"
+    fi
+done
+
 # Start the PLC webserver
-"$OPENPLC_DIR/venvs/runtime/bin/python3" -m "webserver.app"
+"$OPENPLC_DIR/venvs/runtime/bin/python3" -m "webserver.app" $PRINT_DEBUG

--- a/start_openplc.sh
+++ b/start_openplc.sh
@@ -206,13 +206,5 @@ setup_plugin_venvs() {
 setup_plugin_venvs
 setup_runtime_venv
 
-# Parse command line arguments
-PRINT_DEBUG=""
-for arg in "$@"; do
-    if [ "$arg" = "--print-debug" ]; then
-        PRINT_DEBUG="--print-debug"
-    fi
-done
-
-# Start the PLC webserver
-"$OPENPLC_DIR/venvs/runtime/bin/python3" -m "webserver.app" $PRINT_DEBUG
+# Start the PLC webserver (forward all arguments)
+"$OPENPLC_DIR/venvs/runtime/bin/python3" -m "webserver.app" "$@"

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -1,3 +1,13 @@
+import sys
+
+# Parse --print-debug argument before any logger imports
+# This must happen first so LoggerConfig.print_debug is set before loggers are created
+_print_debug = "--print-debug" in sys.argv
+
+from webserver.logger.config import LoggerConfig
+
+LoggerConfig.print_debug = _print_debug
+
 import errno
 import json
 import os
@@ -43,6 +53,7 @@ runtime_manager = RuntimeManager(
     runtime_path="./build/plc_main",
     plc_socket="/run/runtime/plc_runtime.socket",
     log_socket="/run/runtime/log_runtime.socket",
+    print_debug=_print_debug,
 )
 
 runtime_manager.start()

--- a/webserver/logger/__init__.py
+++ b/webserver/logger/__init__.py
@@ -6,6 +6,7 @@ from .logger import get_logger
 from .parser import LogParser
 from .bufferhandler import BufferHandler
 from .formatter import JsonFormatter
+from .config import LoggerConfig
 
 __all__ = ["get_logger", "LogParser", "BufferHandler", "JsonFormatter"]
 __version__ = "0.1"
@@ -19,20 +20,38 @@ shared_buffer_handler = BufferHandler()
 formatter = JsonFormatter()
 shared_buffer_handler.setFormatter(formatter)
 
+
+def _get_effective_level():
+    """Return the effective log level based on print_debug config."""
+    return logging.DEBUG if LoggerConfig.print_debug else logging.INFO
+
+
 def get_logger(name="runtime", use_buffer: bool = False):
     """Return a logger that shares the same buffer handler."""
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
     logger.propagate = False
 
+    effective_level = _get_effective_level()
+
     # Always ensure a StreamHandler exists
     if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setFormatter(JsonFormatter())
+        stream_handler.setLevel(effective_level)
         logger.addHandler(stream_handler)
+    else:
+        # Update existing StreamHandler level
+        for h in logger.handlers:
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, BufferHandler):
+                h.setLevel(effective_level)
 
     if use_buffer:
         if not any(isinstance(h, BufferHandler) for h in logger.handlers):
+            shared_buffer_handler.setLevel(effective_level)
             logger.addHandler(shared_buffer_handler)
+        else:
+            # Update existing BufferHandler level
+            shared_buffer_handler.setLevel(effective_level)
 
     return logger, shared_buffer_handler

--- a/webserver/logger/__init__.py
+++ b/webserver/logger/__init__.py
@@ -34,24 +34,22 @@ def get_logger(name="runtime", use_buffer: bool = False):
 
     effective_level = _get_effective_level()
 
-    # Always ensure a StreamHandler exists
-    if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+    # Ensure a StreamHandler exists
+    if not any(
+        isinstance(h, logging.StreamHandler) and not isinstance(h, BufferHandler)
+        for h in logger.handlers
+    ):
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setFormatter(JsonFormatter())
-        stream_handler.setLevel(effective_level)
         logger.addHandler(stream_handler)
-    else:
-        # Update existing StreamHandler level
-        for h in logger.handlers:
-            if isinstance(h, logging.StreamHandler) and not isinstance(h, BufferHandler):
-                h.setLevel(effective_level)
 
-    if use_buffer:
-        if not any(isinstance(h, BufferHandler) for h in logger.handlers):
-            shared_buffer_handler.setLevel(effective_level)
-            logger.addHandler(shared_buffer_handler)
-        else:
-            # Update existing BufferHandler level
-            shared_buffer_handler.setLevel(effective_level)
+    # Ensure BufferHandler exists if requested
+    if use_buffer and not any(isinstance(h, BufferHandler) for h in logger.handlers):
+        logger.addHandler(shared_buffer_handler)
+
+    # Always update all handler levels to reflect current config
+    for h in logger.handlers:
+        if isinstance(h, logging.StreamHandler):
+            h.setLevel(effective_level)
 
     return logger, shared_buffer_handler

--- a/webserver/logger/config.py
+++ b/webserver/logger/config.py
@@ -6,6 +6,7 @@ class LoggerConfig:
     log_id: int = 0
     log_level: int = logging.INFO
     use_buffer: bool = False
+    print_debug: bool = False
     _log_id_lock = threading.Lock()
 
     @classmethod

--- a/webserver/runtimemanager.py
+++ b/webserver/runtimemanager.py
@@ -25,10 +25,11 @@ if not HAS_PSUTIL:
 
 
 class RuntimeManager:
-    def __init__(self, runtime_path, plc_socket, log_socket):
+    def __init__(self, runtime_path, plc_socket, log_socket, print_debug=False):
         self.runtime_path = runtime_path
         self.plc_socket = plc_socket
         self.log_socket = log_socket
+        self.print_debug = print_debug
         self.process = None
         self.log_server = UnixLogServer(log_socket)
         self.runtime_socket = SyncUnixClient(plc_socket)
@@ -131,7 +132,10 @@ class RuntimeManager:
             logger.info("Starting PLC runtime core...")
             self._safe_start_log_server()
             try:
-                self.process = subprocess.Popen([self.runtime_path])
+                cmd = [self.runtime_path]
+                if self.print_debug:
+                    cmd.append("--print-debug")
+                self.process = subprocess.Popen(cmd)
             except (OSError, subprocess.SubprocessError) as e:
                 logger.error("Failed to start PLC runtime process: %s", e)
                 self.process = None
@@ -170,7 +174,10 @@ class RuntimeManager:
 
                 self._safe_start_log_server()
                 try:
-                    self.process = subprocess.Popen([self.runtime_path])
+                    cmd = [self.runtime_path]
+                    if self.print_debug:
+                        cmd.append("--print-debug")
+                    self.process = subprocess.Popen(cmd)
                 except (OSError, subprocess.SubprocessError) as e:
                     logger.error("Failed to start PLC runtime process: %s", e)
                     self.process = None


### PR DESCRIPTION
By default, debug-level logs are now disabled (no terminal output, no
Unix socket transmission, no REST API exposure). This reduces noise in
production environments.

When --print-debug is passed to start_openplc.sh, it propagates to both
the Python webserver and C runtime, enabling debug logs across all
components:

- C runtime: Only sets LOG_LEVEL_DEBUG when flag is passed
- Python webserver: Sets handler levels to INFO by default, DEBUG with flag
- Plugins: Automatically respect the C runtime log level

https://claude.ai/code/session_01YaVx8wb6vyPSnyfYW6QYMP