### PR TITLE
Add release version tagging to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,14 +2,20 @@ name: Build and Publish Multi-Arch Docker Image
 
 on:
   push:
-    branches: [ main, development ]
+    branches: [ development ]
   pull_request:
     branches: [ main, development ]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       platforms:
         description: 'Platforms to build (comma-separated)'
         default: 'linux/amd64,linux/arm64,linux/arm/v7'
+        required: false
+        type: string
+      release_tag:
+        description: 'Release version tag (e.g., 1.2.3). If provided, also tags as latest.'
         required: false
         type: string
 
@@ -31,18 +37,35 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/autonomy-logic/openplc-runtime
+          tags: |
+            # latest tag for releases or manual runs with release_tag
+            type=raw,value=latest,enable=${{ github.event_name == 'release' || inputs.release_tag != '' }}
+            # SHA tag for branch pushes
+            type=sha,enable=${{ github.event_name == 'push' }}
+            # Version tag for releases (e.g., v1.2.3 -> 1.2.3)
+            type=semver,pattern={{version}}
+            # Version tag for manual runs with release_tag
+            type=raw,value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
+            # development tag for development branch
+            type=raw,value=development,enable=${{ github.ref == 'refs/heads/development' }}
+
       - name: Build and Push Multi-Arch Image
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64,linux/arm/v7' }}
-          tags: |
-            ghcr.io/autonomy-logic/openplc-runtime:latest
-            ghcr.io/autonomy-logic/openplc-runtime:${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- Add release trigger to build Docker images when GitHub releases are published
- Replace hardcoded tags with `docker/metadata-action` for dynamic tag generation
- Add conditional GHCR login (skips on pull requests)
- Add OCI-standard labels for better image traceability
- Remove push trigger for main branch (releases handle production tagging)
- Add optional `release_tag` input for manual workflow runs

## Tagging Behavior

| Event | Tags Generated |
|-------|----------------|
| Push to `development` | `development`, `sha-<short>` |
| Release `v1.2.3` | `latest`, `1.2.3` |
| Manual with `release_tag=1.2.3` | `latest`, `1.2.3` |
| Manual without `release_tag` | `sha-<short>` |
| Pull request | Build only, no push |

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test push to development branch generates correct tags
- [ ] Test release creation generates version tag
- [ ] Test manual run with release_tag input

Generated with [Claude Code](https://claude.ai/code)