### PR TITLE
Fix tag on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,8 +48,8 @@ jobs:
           tags: |
             # latest tag for tag pushes or manual runs with release_tag
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '' }}
-            # Version tag from semver (e.g., v1.2.3 -> 1.2.3)
-            type=semver,pattern={{version}}
+            # Version tag from git tag (e.g., v1.2.3 -> v1.2.3)
+            type=semver,pattern={{raw}}
             # Version tag for manual runs with release_tag
             type=raw,value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
 


### PR DESCRIPTION
This pull request updates the Docker image tagging strategy in the GitHub Actions workflow to use the raw git tag (e.g., `v1.2.3`) instead of stripping the `v` prefix for version tags. This ensures that Docker images are tagged consistently with the git tags, including the `v` prefix.

**Docker image tagging changes:**

* Updated the `type=semver` tag pattern in `.github/workflows/docker.yml` to use `{{raw}}` instead of `{{version}}`, so Docker images are now tagged with the full git tag (e.g., `v1.2.3`), preserving the `v` prefix.