### PR TITLE
fix: Remove leading slash from shm name to fix Python FB on MSYS2

### DIFF
--- a/core/src/plc_app/python_loader.c
+++ b/core/src/plc_app/python_loader.c
@@ -149,7 +149,7 @@ int create_shm_name(char *buf, size_t size)
     }
     close(fd);
 
-    snprintf(buf, size, "/%s", strrchr(shm_mask, '/') + 1);
+    snprintf(buf, size, "%s", strrchr(shm_mask, '/') + 1);
     unlink(shm_mask);
 
     return 0;
@@ -197,8 +197,8 @@ int python_block_loader(const char *script_name, const char *script_content, cha
 
     LOG_INFO("[Python loader] Random shared memory location: %s", shm_name);
 
-    snprintf(shm_in_name, sizeof(shm_in_name), "%s_in", shm_name);
-    snprintf(shm_out_name, sizeof(shm_out_name), "%s_out", shm_name);
+    snprintf(shm_in_name, sizeof(shm_in_name), "/%s_in", shm_name);
+    snprintf(shm_out_name, sizeof(shm_out_name), "/%s_out", shm_name);
 
     // Store names for cleanup
     strncpy(block->shm_in_name, shm_in_name, sizeof(block->shm_in_name) - 1);


### PR DESCRIPTION
The Python script template (from OpenPLC Editor) prepends its own "/" when opening shared memory via posix_ipc. Since create_shm_name() also included a leading "/", the resulting name had a double slash (e.g. "//shmPeD5WxIEWSoz_in"). On Linux this is silently normalized, but on MSYS2/Windows the "//" is treated as a UNC path, causing "Permission denied".

Fix by having create_shm_name() return the bare name (no leading slash) and explicitly prepending "/" in the C-side shm_open() name construction.

https://claude.ai/code/session_01D5xdfbBn2XEWegf9LBTnBH