### PR TITLE
Fix/ethercat soem msys2 build

### DIFF
--- a/core/src/drivers/plugin_driver.c
+++ b/core/src/drivers/plugin_driver.c
@@ -1009,7 +1009,18 @@ int native_plugin_get_symbols(plugin_instance_t *plugin)
     void *handle = dlopen(plugin->config.path, RTLD_LOCAL | RTLD_NOW);
     if (!handle)
     {
-        fprintf(stderr, "Failed to load native plugin '%s': %s\n", plugin->config.path, dlerror());
+        const char *err = dlerror();
+        fprintf(stderr, "Failed to load native plugin '%s': %s\n",
+                plugin->config.path, err ? err : "unknown error");
+        log_error("Failed to load native plugin '%s': %s",
+                  plugin->config.path, err ? err : "unknown error");
+#if defined(__CYGWIN__) || defined(_WIN32)
+        if (strstr(plugin->config.name, "ethercat") != NULL)
+        {
+            log_error("The EtherCAT plugin requires Npcap (https://npcap.com) to access "
+                      "the network interface. Please install Npcap and restart the runtime.");
+        }
+#endif
         free(native_bundle);
         return -1;
     }

--- a/core/src/drivers/plugins/native/ethercat/CMakeLists.txt
+++ b/core/src/drivers/plugins/native/ethercat/CMakeLists.txt
@@ -58,7 +58,16 @@ target_compile_options(soem PUBLIC\n\
 \n\
 # WIN32 is NOT predefined by MSYS2/Cygwin GCC, but the bundled\n\
 # wpcap headers (pcap/pcap.h:40) need it to route to pcap-stdinc.h.\n\
-target_compile_definitions(soem PUBLIC WIN32)\n\
+# HAVE_U_INT*_T tells bundled bittypes.h to skip its typedefs --\n\
+# MSYS2 POSIX headers (sys/types.h) already provide these types and\n\
+# use different underlying types on LP64 (long vs long long for 64-bit).\n\
+target_compile_definitions(soem PUBLIC\n\
+  WIN32\n\
+  HAVE_U_INT8_T\n\
+  HAVE_U_INT16_T\n\
+  HAVE_U_INT32_T\n\
+  HAVE_U_INT64_T\n\
+)\n\
 \n\
 foreach(target IN ITEMS\n\
     soem\n\

--- a/core/src/drivers/plugins/native/ethercat/CMakeLists.txt
+++ b/core/src/drivers/plugins/native/ethercat/CMakeLists.txt
@@ -30,9 +30,8 @@ set(SOEM_BUILD_SAMPLES OFF CACHE BOOL "Disable SOEM samples" FORCE)
 # while the Linux OSHW needs AF_PACKET raw sockets which are unavailable.
 if(CMAKE_SYSTEM_NAME STREQUAL "MSYS" OR CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")
     set(_SOEM_PLATFORM_CMAKE "${SOEM_DIR}/cmake/${CMAKE_SYSTEM_NAME}.cmake")
-    if(NOT EXISTS "${_SOEM_PLATFORM_CMAKE}")
-        message(STATUS "EtherCAT Plugin - Generating ${CMAKE_SYSTEM_NAME}.cmake for SOEM (Win32 OSAL/OSHW via w32api)")
-        file(WRITE "${_SOEM_PLATFORM_CMAKE}" "\
+    message(STATUS "EtherCAT Plugin - Generating ${CMAKE_SYSTEM_NAME}.cmake for SOEM (Win32 OSAL/OSHW via w32api)")
+    file(WRITE "${_SOEM_PLATFORM_CMAKE}" "\
 # Auto-generated for ${CMAKE_SYSTEM_NAME} -- based on Windows.cmake\n\
 # Uses Win32 OSAL/OSHW accessible through w32api on MSYS2/Cygwin.\n\
 \n\
@@ -111,7 +110,6 @@ install(FILES\n\
   DESTINATION include/soem\n\
 )\n\
 ")
-    endif()
     unset(_SOEM_PLATFORM_CMAKE)
 endif()
 

--- a/core/src/drivers/plugins/native/ethercat/CMakeLists.txt
+++ b/core/src/drivers/plugins/native/ethercat/CMakeLists.txt
@@ -23,6 +23,89 @@ message(STATUS "EtherCAT Plugin - OpenPLC root: ${OPENPLC_ROOT}")
 
 set(SOEM_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs/soem)
 set(SOEM_BUILD_SAMPLES OFF CACHE BOOL "Disable SOEM samples" FORCE)
+
+# On MSYS2/Cygwin, SOEM ships no platform cmake file (only Linux.cmake,
+# Windows.cmake, rt-kernel.cmake exist).  Generate one from the Win32
+# variant because MSYS2 can use Win32 OSAL/OSHW through w32api headers
+# while the Linux OSHW needs AF_PACKET raw sockets which are unavailable.
+if(CMAKE_SYSTEM_NAME STREQUAL "MSYS" OR CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")
+    set(_SOEM_PLATFORM_CMAKE "${SOEM_DIR}/cmake/${CMAKE_SYSTEM_NAME}.cmake")
+    if(NOT EXISTS "${_SOEM_PLATFORM_CMAKE}")
+        message(STATUS "EtherCAT Plugin - Generating ${CMAKE_SYSTEM_NAME}.cmake for SOEM (Win32 OSAL/OSHW via w32api)")
+        file(WRITE "${_SOEM_PLATFORM_CMAKE}" "\
+# Auto-generated for ${CMAKE_SYSTEM_NAME} -- based on Windows.cmake\n\
+# Uses Win32 OSAL/OSHW accessible through w32api on MSYS2/Cygwin.\n\
+\n\
+target_sources(soem PRIVATE\n\
+  osal/win32/osal.c\n\
+  osal/win32/osal_defs.h\n\
+  oshw/win32/oshw.c\n\
+  oshw/win32/oshw.h\n\
+  oshw/win32/nicdrv.c\n\
+  oshw/win32/nicdrv.h\n\
+)\n\
+\n\
+target_include_directories(soem PUBLIC\n\
+  $<BUILD_INTERFACE:\${SOEM_SOURCE_DIR}/osal/win32>\n\
+  $<BUILD_INTERFACE:\${SOEM_SOURCE_DIR}/oshw/win32>\n\
+  $<BUILD_INTERFACE:\${SOEM_SOURCE_DIR}/oshw/win32/wpcap/Include>\n\
+  $<INSTALL_INTERFACE:include/soem>\n\
+)\n\
+\n\
+target_compile_options(soem PUBLIC\n\
+  $<$<C_COMPILER_ID:GNU>:-std=c11>\n\
+)\n\
+\n\
+# WIN32 is NOT predefined by MSYS2/Cygwin GCC, but the bundled\n\
+# wpcap headers (pcap/pcap.h:40) need it to route to pcap-stdinc.h.\n\
+target_compile_definitions(soem PUBLIC WIN32)\n\
+\n\
+foreach(target IN ITEMS\n\
+    soem\n\
+    ec_sample\n\
+    eepromtool\n\
+    eni_test\n\
+    eoe_test\n\
+    firm_update\n\
+    simple_ng\n\
+    slaveinfo)\n\
+  if (TARGET \${target})\n\
+    target_compile_options(\${target} PRIVATE\n\
+      $<$<C_COMPILER_ID:GNU>:\n\
+      -Wall\n\
+      -Wextra\n\
+      -Wno-unused-parameter\n\
+      >\n\
+    )\n\
+  endif()\n\
+endforeach()\n\
+\n\
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)\n\
+  set(WPCAP_LIB_PATH \${SOEM_SOURCE_DIR}/oshw/win32/wpcap/Lib/x64)\n\
+  target_link_libraries(soem PUBLIC\n\
+    \${WPCAP_LIB_PATH}/wpcap.lib\n\
+    \${WPCAP_LIB_PATH}/Packet.lib\n\
+  )\n\
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)\n\
+  set(WPCAP_LIB_PATH \${SOEM_SOURCE_DIR}/oshw/win32/wpcap/Lib)\n\
+  target_link_libraries(soem PUBLIC\n\
+    \${WPCAP_LIB_PATH}/libwpcap.a\n\
+    \${WPCAP_LIB_PATH}/libpacket.a\n\
+  )\n\
+endif()\n\
+\n\
+target_link_libraries(soem PUBLIC ws2_32 winmm)\n\
+\n\
+install(FILES\n\
+  osal/win32/osal_defs.h\n\
+  oshw/win32/nicdrv.h\n\
+  DESTINATION include/soem\n\
+)\n\
+")
+    endif()
+    unset(_SOEM_PLATFORM_CMAKE)
+endif()
+
 add_subdirectory(${SOEM_DIR} ${CMAKE_CURRENT_BINARY_DIR}/soem)
 
 # =============================================================================

--- a/core/src/drivers/plugins/native/ethercat/ethercat_master.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_master.c
@@ -112,11 +112,20 @@ int ecat_master_init(const ecat_config_t *config, plugin_logger_t *logger)
     plugin_logger_info(logger, "Opening network interface: %s", config->master.interface);
 
     if (!ecx_init(&g_ecx_context, config->master.interface)) {
+#if defined(__CYGWIN__) || defined(_WIN32)
+        plugin_logger_error(logger,
+            "Failed to initialize EtherCAT interface '%s'. "
+            "Verify that Npcap (https://npcap.com) is installed and "
+            "the interface name matches a network adapter (use "
+            "'ipconfig' or Npcap's WlanHelper to list adapters).",
+            config->master.interface);
+#else
         plugin_logger_error(logger,
             "Failed to initialize EtherCAT interface '%s'. "
             "Check that the interface exists and the process has "
             "CAP_NET_RAW capability (or is running as root).",
             config->master.interface);
+#endif
         return -1;
     }
 

--- a/install.sh
+++ b/install.sh
@@ -262,7 +262,9 @@ install_deps_msys2() {
         python-setuptools \
         python-cryptography \
         git \
-        sqlite3
+        sqlite3 \
+        msys2-w32api-headers \
+        msys2-w32api-runtime
 }
 
 compile_plc() {

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ pytest-flask
 pre-commit
 psutil; sys_platform != "cygwin"
 pyserial>=3.5
-flasgger>=0.9.7


### PR DESCRIPTION
This pull request improves support for running the EtherCAT plugin on Windows and Cygwin/MSYS2 environments, especially addressing the use of the SOEM library and network interface access requirements. The changes enhance error reporting, automate platform-specific configuration, and ensure necessary dependencies are installed.

**Platform support and build configuration:**

* Automatically generates a SOEM platform CMake file for MSYS2/Cygwin based on the Windows configuration, enabling proper compilation and linking using Win32 OSAL/OSHW via w32api headers. This includes setting source files, include directories, compile options, and linking with the appropriate libraries. (`core/src/drivers/plugins/native/ethercat/CMakeLists.txt`, [core/src/drivers/plugins/native/ethercat/CMakeLists.txtR26-R115](diffhunk://#diff-1c1b3459378cb6793ba3954b47be87745d27c441b1b7275deec742dd5ab00eaaR26-R115))
* Adds MSYS2-specific dependencies (`msys2-w32api-headers`, `msys2-w32api-runtime`) to the install script to ensure the build environment has the required headers and runtime for Win32 compatibility. (`install.sh`, [install.shL265-R267](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL265-R267))

**Improved error handling and user guidance:**

* Enhances error logging when loading native plugins, specifically providing guidance for EtherCAT plugin failures on Windows/Cygwin by recommending Npcap installation. (`core/src/drivers/plugin_driver.c`, [core/src/drivers/plugin_driver.cL1012-R1023](diffhunk://#diff-25e8706ac23e43446d1ac4895807d60c61e070fe8dbaf6130eabd41dafe5c3a3L1012-R1023))
* Refines EtherCAT interface initialization error messages: on Windows/Cygwin, suggests verifying Npcap installation and network adapter name, while on other platforms, reminds users about interface existence and required privileges. (`core/src/drivers/plugins/native/ethercat/ethercat_master.c`, [core/src/drivers/plugins/native/ethercat/ethercat_master.cR115-R128](diffhunk://#diff-d4446deafcf16f373736140df20ef1c70501f7a3efd54b80e05a4518b8546430R115-R128))