### PR TITLE
feat: Three-layer crash recovery to prevent restart loops

### DIFF
--- a/core/src/plc_app/plc_main.c
+++ b/core/src/plc_app/plc_main.c
@@ -36,6 +36,7 @@ void handle_sigint(int sig)
 int main(int argc, char *argv[])
 {
     bool print_debug = false;
+    bool safe_mode   = false;
 
     // Check for command line arguments
     for (int i = 1; i < argc; i++)
@@ -48,11 +49,9 @@ int main(int argc, char *argv[])
         {
             print_debug = true;
         }
-
-        // Early exit if both flags are found
-        if (print_logs && print_debug)
+        else if (strcmp(argv[i], "--safe-mode") == 0)
         {
-            break;
+            safe_mode = true;
         }
     }
 
@@ -98,8 +97,14 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    // Start PLC
-    if (plc_set_state(PLC_STATE_RUNNING) != true)
+    // Start PLC (skip in safe mode to allow program upload without loading the
+    // faulty program that may have caused repeated crashes)
+    if (safe_mode)
+    {
+        log_info("Runtime started in SAFE MODE - PLC program will not be loaded");
+        log_info("Upload a corrected program to recover");
+    }
+    else if (plc_set_state(PLC_STATE_RUNNING) != true)
     {
         log_error("Failed to set PLC state to RUNNING");
     }

--- a/core/src/plc_app/plc_state_manager.c
+++ b/core/src/plc_app/plc_state_manager.c
@@ -28,6 +28,7 @@ extern plugin_driver_t *plugin_driver;
 static sigjmp_buf plc_crash_jmp;
 static pthread_t plc_thread_id;
 static volatile sig_atomic_t plc_crash_signal = 0;
+static volatile sig_atomic_t holding_buffer_mutex = 0;
 
 static void plc_crash_handler(int sig)
 {
@@ -50,6 +51,7 @@ void *plc_cycle_thread(void *arg)
 
     // Record this thread's ID for the crash handler
     plc_thread_id = pthread_self();
+    plc_crash_signal = 0;
 
     // Initialize PLC with real-time optimizations
     set_realtime_priority();
@@ -122,8 +124,12 @@ void *plc_cycle_thread(void *arg)
     if (crash_sig != 0)
     {
         // We got here via siglongjmp from the crash handler.
-        // Release the buffer mutex in case we held it when we crashed.
-        plugin_mutex_give(&plugin_driver->buffer_mutex);
+        // Only release the buffer mutex if we held it when we crashed.
+        if (holding_buffer_mutex)
+        {
+            holding_buffer_mutex = 0;
+            plugin_mutex_give(&plugin_driver->buffer_mutex);
+        }
 
         const char *sig_name = (crash_sig == SIGFPE) ? "SIGFPE (arithmetic error, e.g. division by zero)"
                                                       : "SIGSEGV (memory access violation)";
@@ -147,6 +153,7 @@ void *plc_cycle_thread(void *arg)
     while (plc_state == PLC_STATE_RUNNING)
     {
         scan_cycle_time_start();
+        holding_buffer_mutex = 1;
         plugin_mutex_take(&plugin_driver->buffer_mutex);
 
         // Apply pending journal entries before plugin hooks run
@@ -167,6 +174,7 @@ void *plc_cycle_thread(void *arg)
         atomic_store(&plc_heartbeat, time(NULL));
 
         plugin_mutex_give(&plugin_driver->buffer_mutex);
+        holding_buffer_mutex = 0;
         scan_cycle_time_end();
 
         // Calculate next start time
@@ -392,6 +400,14 @@ void plc_state_manager_cleanup(void)
     {
         unload_plc_program(plc_program);
     }
+}
+
+void plc_force_error_state(void)
+{
+    pthread_mutex_lock(&state_mutex);
+    plc_state = PLC_STATE_ERROR;
+    pthread_mutex_unlock(&state_mutex);
+    log_info("PLC State: ERROR");
 }
 
 int plc_get_crash_signal(void)

--- a/core/src/plc_app/plc_state_manager.c
+++ b/core/src/plc_app/plc_state_manager.c
@@ -1,5 +1,8 @@
 #include <pthread.h>
+#include <setjmp.h>
+#include <signal.h>
 #include <stdatomic.h>
+#include <string.h>
 
 #include "../drivers/plugin_driver.h"
 #include "image_tables.h"
@@ -21,9 +24,32 @@ extern plc_timing_stats_t plc_timing_stats;
 extern atomic_long plc_heartbeat;
 extern plugin_driver_t *plugin_driver;
 
+// Signal recovery for PLC cycle thread crashes (SIGFPE, SIGSEGV)
+static sigjmp_buf plc_crash_jmp;
+static pthread_t plc_thread_id;
+static volatile sig_atomic_t plc_crash_signal = 0;
+
+static void plc_crash_handler(int sig)
+{
+    // Only handle if the crash came from the PLC cycle thread
+    if (!pthread_equal(pthread_self(), plc_thread_id))
+    {
+        // Not our thread - restore default handler and re-raise
+        signal(sig, SIG_DFL);
+        raise(sig);
+        return;
+    }
+
+    plc_crash_signal = sig;
+    siglongjmp(plc_crash_jmp, sig);
+}
+
 void *plc_cycle_thread(void *arg)
 {
     PluginManager *pm = (PluginManager *)arg;
+
+    // Record this thread's ID for the crash handler
+    plc_thread_id = pthread_self();
 
     // Initialize PLC with real-time optimizations
     set_realtime_priority();
@@ -63,6 +89,20 @@ void *plc_cycle_thread(void *arg)
         log_info("Journal buffer initialized");
     }
 
+    // Install signal handlers for crash recovery BEFORE entering the main loop.
+    // This allows SIGFPE (e.g. division by zero) and SIGSEGV (e.g. bad array
+    // access) in the user's PLC program to be caught and recovered from,
+    // instead of killing the entire runtime process.
+    struct sigaction crash_sa;
+    memset(&crash_sa, 0, sizeof(crash_sa));
+    crash_sa.sa_handler = plc_crash_handler;
+    sigemptyset(&crash_sa.sa_mask);
+    // SA_NODEFER: allow the handler to catch the same signal again after
+    // siglongjmp returns (needed because the signal is still blocked otherwise)
+    crash_sa.sa_flags = SA_NODEFER;
+    sigaction(SIGFPE, &crash_sa, NULL);
+    sigaction(SIGSEGV, &crash_sa, NULL);
+
     log_info("Starting main loop");
 
     pthread_mutex_lock(&state_mutex);
@@ -74,6 +114,35 @@ void *plc_cycle_thread(void *arg)
 
     // Get the start time for the running program
     clock_gettime(CLOCK_MONOTONIC, &timer_start);
+
+    // Set up the crash recovery point. sigsetjmp returns 0 on initial call,
+    // and returns the signal number when siglongjmp jumps back here after
+    // a crash in the PLC program.
+    int crash_sig = sigsetjmp(plc_crash_jmp, 1);
+    if (crash_sig != 0)
+    {
+        // We got here via siglongjmp from the crash handler.
+        // Release the buffer mutex in case we held it when we crashed.
+        plugin_mutex_give(&plugin_driver->buffer_mutex);
+
+        const char *sig_name = (crash_sig == SIGFPE) ? "SIGFPE (arithmetic error, e.g. division by zero)"
+                                                      : "SIGSEGV (memory access violation)";
+        log_error("PLC program crashed with signal %d: %s", crash_sig, sig_name);
+        log_error("The loaded PLC program contains a fatal error. "
+                  "Upload a corrected program to recover.");
+
+        // Restore default handlers so crashes outside the PLC thread
+        // still terminate the process as expected
+        signal(SIGFPE, SIG_DFL);
+        signal(SIGSEGV, SIG_DFL);
+
+        pthread_mutex_lock(&state_mutex);
+        plc_state = PLC_STATE_ERROR;
+        pthread_mutex_unlock(&state_mutex);
+        log_info("PLC State: ERROR");
+
+        return NULL;
+    }
 
     while (plc_state == PLC_STATE_RUNNING)
     {
@@ -107,6 +176,10 @@ void *plc_cycle_thread(void *arg)
         // Sleep until the next cycle should start
         sleep_until(&timer_start);
     }
+
+    // Restore default signal handlers when exiting normally
+    signal(SIGFPE, SIG_DFL);
+    signal(SIGSEGV, SIG_DFL);
 
     return NULL;
 }
@@ -183,10 +256,18 @@ int unload_plc_program(PluginManager *pm)
 {
     if (pm && pm == plc_program)
     {
-        // Signal the PLC thread to stop
-        pthread_mutex_lock(&state_mutex);
-        plc_state = PLC_STATE_STOPPED;
-        pthread_mutex_unlock(&state_mutex);
+        // Check if we are coming from ERROR state (crash recovery).
+        // In that case, the PLC thread has already exited via the signal
+        // handler, so we only need to join it without changing state first.
+        PLCState prev_state = plc_get_state();
+
+        if (prev_state != PLC_STATE_ERROR)
+        {
+            // Normal shutdown: signal the PLC thread to stop
+            pthread_mutex_lock(&state_mutex);
+            plc_state = PLC_STATE_STOPPED;
+            pthread_mutex_unlock(&state_mutex);
+        }
 
         // Wait for the PLC thread to finish
         pthread_join(plc_thread, NULL);
@@ -293,9 +374,12 @@ bool plc_set_state(PLCState new_state)
     // Handle transition to stopped
     else if (new_state == PLC_STATE_STOPPED)
     {
-        if (unload_plc_program(plc_program) < 0)
+        if (plc_program)
         {
-            return false;
+            if (unload_plc_program(plc_program) < 0)
+            {
+                return false;
+            }
         }
     }
 
@@ -308,4 +392,9 @@ void plc_state_manager_cleanup(void)
     {
         unload_plc_program(plc_program);
     }
+}
+
+int plc_get_crash_signal(void)
+{
+    return (int)plc_crash_signal;
 }

--- a/core/src/plc_app/plc_state_manager.c
+++ b/core/src/plc_app/plc_state_manager.c
@@ -30,6 +30,20 @@ static pthread_t plc_thread_id;
 static volatile sig_atomic_t plc_crash_signal = 0;
 static volatile sig_atomic_t holding_buffer_mutex = 0;
 
+// NOTE on siglongjmp safety: siglongjmp from a hardware-raised signal is
+// well-defined when process state (heap/stack) is intact at the time of the
+// signal. For generated PLC code this is the expected case because:
+//   - SIGFPE: the faulting instruction is trapped before completing, no
+//     memory is modified, so recovery is always safe.
+//   - SIGSEGV: typically caused by out-of-bounds access into an unmapped
+//     page. The write/read is trapped by the MMU before completing, so
+//     process state is clean.
+// The theoretical risk is a SIGSEGV caused by a prior silent corruption
+// (write to a valid but wrong address) leaving heap/stack inconsistent.
+// This is extremely unlikely with generated PLC code (no heap allocation,
+// no recursion). If it does happen, the recovered process will crash again
+// shortly and Layer 3 (webserver safe mode) will catch the rapid crash
+// pattern and restart without loading the faulty program.
 static void plc_crash_handler(int sig)
 {
     // Only handle if the crash came from the PLC cycle thread

--- a/core/src/plc_app/plc_state_manager.h
+++ b/core/src/plc_app/plc_state_manager.h
@@ -32,4 +32,10 @@ bool plc_set_state(PLCState new_state);
  */
 void plc_state_manager_cleanup(void);
 
+/**
+ * @brief Get the signal number that caused the last PLC crash.
+ * @return The signal number (e.g. SIGFPE, SIGSEGV), or 0 if no crash occurred
+ */
+int plc_get_crash_signal(void);
+
 #endif // PLC_STATE_MANAGER_H

--- a/core/src/plc_app/plc_state_manager.h
+++ b/core/src/plc_app/plc_state_manager.h
@@ -33,6 +33,14 @@ bool plc_set_state(PLCState new_state);
 void plc_state_manager_cleanup(void);
 
 /**
+ * @brief Force the PLC into ERROR state from any thread.
+ *
+ * This is intended for the watchdog thread to transition the PLC to ERROR
+ * state without triggering program load/unload side effects (unlike plc_set_state).
+ */
+void plc_force_error_state(void);
+
+/**
  * @brief Get the signal number that caused the last PLC crash.
  * @return The signal number (e.g. SIGFPE, SIGSEGV), or 0 if no crash occurred
  */

--- a/core/src/plc_app/utils/watchdog.c
+++ b/core/src/plc_app/utils/watchdog.c
@@ -30,14 +30,23 @@ void *watchdog_thread(void *arg)
         long now = atomic_load(&plc_heartbeat);
         if (now == last)
         {
-            // Use stderr to ensure visibility and avoid lockups in log system
-            time_t now_time = time(NULL);
-            struct tm t;
-            gmtime_r(&now_time, &t);
-            char time_buf[20];
-            strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", &t);
-            fprintf(stderr, "[%s] [ERROR] Watchdog: No heartbeat! PLC unresponsive.\n", time_buf);
-            exit(EXIT_FAILURE);
+            log_error("Watchdog: No heartbeat detected - PLC program is unresponsive");
+            log_error("The loaded PLC program may contain an infinite loop. "
+                      "Upload a corrected program to recover.");
+
+            // Transition to ERROR state instead of killing the process.
+            // This keeps the runtime alive so the webserver can still
+            // communicate with it and upload a new program.
+            // Writing directly to plc_state is safe here because the PLC
+            // thread is unresponsive (stuck) and not contending the variable.
+            // The main loop checks plc_state each cycle and will exit.
+            plc_state = PLC_STATE_ERROR;
+            log_info("PLC State: ERROR");
+
+            // Reset heartbeat tracking for next run
+            last = 0;
+            atomic_store(&plc_heartbeat, 0);
+            continue;
         }
 
         last = now;

--- a/core/src/plc_app/utils/watchdog.c
+++ b/core/src/plc_app/utils/watchdog.c
@@ -11,7 +11,6 @@
 #include "watchdog.h"
 
 atomic_long plc_heartbeat;
-extern PLCState plc_state;
 
 void *watchdog_thread(void *arg)
 {
@@ -22,9 +21,17 @@ void *watchdog_thread(void *arg)
     {
         sleep(2); // Watch every 2 seconds
 
-        if (plc_get_state() != PLC_STATE_RUNNING)
+        PLCState current_state = plc_get_state();
+        if (current_state != PLC_STATE_RUNNING)
         {
-            continue; // Only monitor when PLC is running
+            // Reset tracking when not running so we get a fresh
+            // baseline when the PLC starts again
+            if (current_state == PLC_STATE_ERROR)
+            {
+                last = 0;
+                atomic_store(&plc_heartbeat, 0);
+            }
+            continue;
         }
 
         long now = atomic_load(&plc_heartbeat);
@@ -37,15 +44,7 @@ void *watchdog_thread(void *arg)
             // Transition to ERROR state instead of killing the process.
             // This keeps the runtime alive so the webserver can still
             // communicate with it and upload a new program.
-            // Writing directly to plc_state is safe here because the PLC
-            // thread is unresponsive (stuck) and not contending the variable.
-            // The main loop checks plc_state each cycle and will exit.
-            plc_state = PLC_STATE_ERROR;
-            log_info("PLC State: ERROR");
-
-            // Reset heartbeat tracking for next run
-            last = 0;
-            atomic_store(&plc_heartbeat, 0);
+            plc_force_error_state();
             continue;
         }
 

--- a/webserver/plcapp_management.py
+++ b/webserver/plcapp_management.py
@@ -293,6 +293,7 @@ def run_compile(runtime_manager: RuntimeManager, cwd: str = "core/generated"):
 
     # Restart PLC only if everything succeeded
     if build_state.status == BuildStatus.SUCCESS:
+        runtime_manager.reset_crash_tracking()
         runtime_manager.start_plc()
     else:
         build_state.log("[WARNING] PLC program has not been updated because the build failed\n")

--- a/webserver/runtimemanager.py
+++ b/webserver/runtimemanager.py
@@ -24,6 +24,10 @@ if not HAS_PSUTIL:
     logger.info("psutil not available - process detection features disabled")
 
 
+MAX_RAPID_CRASHES = 3
+RAPID_CRASH_WINDOW = 30  # seconds
+
+
 class RuntimeManager:
     def __init__(self, runtime_path, plc_socket, log_socket, print_debug=False):
         self.runtime_path = runtime_path
@@ -35,6 +39,8 @@ class RuntimeManager:
         self.runtime_socket = SyncUnixClient(plc_socket)
         self.monitor_thread = threading.Thread(target=self._monitor, daemon=True)
         self.running = False
+        self._crash_times: list[float] = []
+        self._safe_mode = False
 
     def find_running_process(self):
         """
@@ -161,28 +167,56 @@ class RuntimeManager:
                 return True
         return False
 
+    def _start_runtime_process(self, safe_mode=False):
+        """Start the runtime process, optionally in safe mode."""
+        self._safe_start_log_server()
+        try:
+            cmd = [self.runtime_path]
+            if self.print_debug:
+                cmd.append("--print-debug")
+            if safe_mode:
+                cmd.append("--safe-mode")
+            self.process = subprocess.Popen(cmd)
+        except (OSError, subprocess.SubprocessError) as e:
+            logger.error("Failed to start PLC runtime process: %s", e)
+            self.process = None
+        time.sleep(1)  # Give time to start
+        self._safe_connect_runtime_socket()
+
+    def _should_enter_safe_mode(self):
+        """Check if recent crashes warrant entering safe mode."""
+        now = time.time()
+        # Keep only crashes within the time window
+        self._crash_times = [t for t in self._crash_times if now - t < RAPID_CRASH_WINDOW]
+        self._crash_times.append(now)
+        return len(self._crash_times) >= MAX_RAPID_CRASHES
+
     def _monitor(self):
         """
-        Monitor the PLC runtime process and restart if it dies
+        Monitor the PLC runtime process and restart if it dies.
+        Tracks crash frequency and enters safe mode after repeated failures.
         """
         while self.running:
             if not self.is_runtime_alive():
-                # Process died, restart
-                logger.warning("PLC runtime process died, restarting...")
+                logger.warning("PLC runtime process died unexpectedly")
                 self._safe_stop_log_server()
                 self._safe_close_runtime_socket()
 
-                self._safe_start_log_server()
-                try:
-                    cmd = [self.runtime_path]
-                    if self.print_debug:
-                        cmd.append("--print-debug")
-                    self.process = subprocess.Popen(cmd)
-                except (OSError, subprocess.SubprocessError) as e:
-                    logger.error("Failed to start PLC runtime process: %s", e)
-                    self.process = None
-                time.sleep(1)  # Give time to start
-                self._safe_connect_runtime_socket()
+                if self._should_enter_safe_mode():
+                    if not self._safe_mode:
+                        logger.error(
+                            "PLC program caused %d crashes within %d seconds. "
+                            "Restarting runtime in SAFE MODE - "
+                            "PLC program will NOT be loaded. "
+                            "Upload a corrected program to recover.",
+                            MAX_RAPID_CRASHES,
+                            RAPID_CRASH_WINDOW,
+                        )
+                        self._safe_mode = True
+                    self._start_runtime_process(safe_mode=True)
+                else:
+                    logger.warning("Restarting PLC runtime...")
+                    self._start_runtime_process(safe_mode=False)
             else:
                 # Make sure log server and socket are connected
                 if not self.log_server.running:
@@ -221,6 +255,11 @@ class RuntimeManager:
             self.process = None
         self._safe_stop_log_server()
         self._safe_close_runtime_socket()
+
+    def reset_crash_tracking(self):
+        """Reset crash tracking state after a successful program upload."""
+        self._crash_times.clear()
+        self._safe_mode = False
 
     def get_logs(self, min_id=None, level=None):
         """

--- a/webserver/runtimemanager.py
+++ b/webserver/runtimemanager.py
@@ -39,6 +39,7 @@ class RuntimeManager:
         self.runtime_socket = SyncUnixClient(plc_socket)
         self.monitor_thread = threading.Thread(target=self._monitor, daemon=True)
         self.running = False
+        self._crash_lock = threading.Lock()
         self._crash_times: list[float] = []
         self._safe_mode = False
 
@@ -183,13 +184,14 @@ class RuntimeManager:
         time.sleep(1)  # Give time to start
         self._safe_connect_runtime_socket()
 
-    def _should_enter_safe_mode(self):
-        """Check if recent crashes warrant entering safe mode."""
-        now = time.time()
-        # Keep only crashes within the time window
-        self._crash_times = [t for t in self._crash_times if now - t < RAPID_CRASH_WINDOW]
-        self._crash_times.append(now)
-        return len(self._crash_times) >= MAX_RAPID_CRASHES
+    def _record_crash_and_check_safe_mode(self):
+        """Record a crash timestamp and check if safe mode should be entered."""
+        with self._crash_lock:
+            now = time.time()
+            # Keep only crashes within the time window
+            self._crash_times = [t for t in self._crash_times if now - t < RAPID_CRASH_WINDOW]
+            self._crash_times.append(now)
+            return len(self._crash_times) >= MAX_RAPID_CRASHES
 
     def _monitor(self):
         """
@@ -202,17 +204,18 @@ class RuntimeManager:
                 self._safe_stop_log_server()
                 self._safe_close_runtime_socket()
 
-                if self._should_enter_safe_mode():
-                    if not self._safe_mode:
-                        logger.error(
-                            "PLC program caused %d crashes within %d seconds. "
-                            "Restarting runtime in SAFE MODE - "
-                            "PLC program will NOT be loaded. "
-                            "Upload a corrected program to recover.",
-                            MAX_RAPID_CRASHES,
-                            RAPID_CRASH_WINDOW,
-                        )
-                        self._safe_mode = True
+                if self._record_crash_and_check_safe_mode():
+                    with self._crash_lock:
+                        if not self._safe_mode:
+                            logger.error(
+                                "PLC program caused %d crashes within %d seconds. "
+                                "Restarting runtime in SAFE MODE - "
+                                "PLC program will NOT be loaded. "
+                                "Upload a corrected program to recover.",
+                                MAX_RAPID_CRASHES,
+                                RAPID_CRASH_WINDOW,
+                            )
+                            self._safe_mode = True
                     self._start_runtime_process(safe_mode=True)
                 else:
                     logger.warning("Restarting PLC runtime...")
@@ -258,8 +261,9 @@ class RuntimeManager:
 
     def reset_crash_tracking(self):
         """Reset crash tracking state after a successful program upload."""
-        self._crash_times.clear()
-        self._safe_mode = False
+        with self._crash_lock:
+            self._crash_times.clear()
+            self._safe_mode = False
 
     def get_logs(self, min_id=None, level=None):
         """


### PR DESCRIPTION
## Summary

- **Layer 1 - Signal handler**: Catch SIGFPE/SIGSEGV in the PLC cycle thread via `sigsetjmp`/`siglongjmp`, transitioning to ERROR state while keeping the runtime process alive so the command socket remains available for uploading a corrected program
- **Layer 2 - Watchdog recovery**: Transition to ERROR state instead of `exit()` when the watchdog detects an unresponsive PLC (e.g. infinite loop), keeping the runtime alive for recovery
- **Layer 3 - Webserver safe mode fallback**: Track crash frequency with a sliding window; after 3 crashes within 30 seconds, restart the runtime with `--safe-mode` flag which skips loading the PLC program, allowing a new program to be uploaded
- Reset crash tracking state after successful program compilation

## Context

When a PLC program contains fatal errors (division by zero, bad array access, infinite loops), the runtime would crash and the webserver would blindly restart it in an infinite loop, making recovery impossible without manually killing the processes.

## Test plan

- [ ] Upload a PLC program with division by zero (SIGFPE) — runtime should enter ERROR state, process stays alive, new program can be uploaded
- [ ] Upload a PLC program with out-of-bounds array access (SIGSEGV) — same recovery behavior
- [ ] Upload a PLC program with an infinite loop — watchdog transitions to ERROR, runtime stays alive
- [ ] Kill the runtime process manually 3 times rapidly — webserver should detect crash loop and restart in safe mode
- [ ] After safe mode, upload a valid program — crash tracking resets, PLC runs normally
- [ ] Normal PLC programs continue to work without any behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)