### PR TITLE
fix: Stop plugins by running flag and defer plugin start to PLC load

### DIFF
--- a/core/src/drivers/plugin_driver.c
+++ b/core/src/drivers/plugin_driver.c
@@ -496,31 +496,23 @@ int plugin_driver_stop(plugin_driver_t *driver)
         local_gstate = PyGILState_Ensure();
     }
 
-    // Signal all plugins to stop
+    // Signal all running plugins to stop.
+    // Stop based on the running flag, not the enabled flag, because a plugin
+    // may have been disabled via config update while still running.
     for (int i = 0; i < driver->plugin_count; i++)
     {
         plugin_instance_t *plugin = &driver->plugins[i];
-        
-        // Skip disabled plugins
-        if (!plugin->config.enabled)
+
+        if (!plugin->running)
         {
-            log_info("Skipping disabled plugin during stop: %s", plugin->config.name);
             continue;
         }
-        
-        log_info("Stopping plugin %d/%d: %s", i + 1, driver->plugin_count,
-                 driver->plugins[i].config.name);
-        if (plugin->python_plugin && plugin->python_plugin->pFuncStop &&
-            plugin->running)
-        {
-            plugin_instance_t *plugin = &driver->plugins[i];
-            if (plugin->config.enabled == 0)
-            {
-                log_info("Plugin %s is disabled, skipping stop", plugin->config.name);
-                continue;
-            }
 
-            PyObject *res = PyObject_CallNoArgs(driver->plugins[i].python_plugin->pFuncStop);
+        log_info("Stopping plugin %d/%d: %s", i + 1, driver->plugin_count,
+                 plugin->config.name);
+        if (plugin->python_plugin && plugin->python_plugin->pFuncStop)
+        {
+            PyObject *res = PyObject_CallNoArgs(plugin->python_plugin->pFuncStop);
             if (!res)
             {
                 PyErr_Print();
@@ -529,20 +521,16 @@ int plugin_driver_stop(plugin_driver_t *driver)
             else
             {
                 log_info("Plugin %s stopped successfully", plugin->config.name);
+                Py_DECREF(res);
             }
-            Py_DECREF(res);
-            log_info("Plugin %s stopped", driver->plugins[i].config.name);
             plugin->running = 0;
         }
-
-        else if (plugin->native_plugin && plugin->native_plugin->stop &&
-                 plugin->running)
+        else if (plugin->native_plugin && plugin->native_plugin->stop)
         {
             plugin->native_plugin->stop();
             log_info("Native plugin %s stopped successfully", plugin->config.name);
             plugin->running = 0;
         }
-        // Plugin manager only handles destruction, not stopping
     }
 
     if (need_gil)

--- a/core/src/plc_app/plc_main.c
+++ b/core/src/plc_app/plc_main.c
@@ -109,31 +109,32 @@ int main(int argc, char *argv[])
         log_error("Failed to set PLC state to RUNNING");
     }
 
-    // Initialize plugin driver system
+    // Initialize plugin driver system.
+    // Only load config and symbols here — plugins are started later when
+    // a PLC program is loaded (in load_plc_program). Starting plugins at
+    // boot would cause errors because buffer pointers are NULL until
+    // a PLC program populates them.
     plugin_driver = plugin_driver_create();
     if (plugin_driver)
     {
         log_info("[PLUGIN]: Plugin driver system created");
-        // Load plugin configuration
         if (plugin_driver_load_config(plugin_driver, "./plugins.conf") == 0)
         {
-            // Start plugins
-            plugin_driver_init(plugin_driver);
-            plugin_driver_start(plugin_driver);
-            log_info("[PLUGIN]: Plugin driver system initialized");
+            log_info("[PLUGIN]: Plugin driver configuration loaded");
         }
         else
         {
             log_error("[PLUGIN]: Failed to load plugin configuration");
-            // Release the Python GIL if Python was initialized during plugin loading.
-            // This prevents a deadlock where the main thread holds the GIL forever
-            // while sleeping, blocking other threads (like the unix socket thread)
-            // from using Python when handling commands like START.
-            if (Py_IsInitialized())
-            {
-                PyEval_SaveThread();
-                log_info("[PLUGIN]: Released Python GIL after failed plugin load");
-            }
+        }
+
+        // Release the Python GIL if Python was initialized during plugin loading.
+        // This prevents a deadlock where the main thread holds the GIL forever
+        // while sleeping, blocking other threads (like the unix socket thread)
+        // from using Python when handling commands like START.
+        if (Py_IsInitialized())
+        {
+            PyEval_SaveThread();
+            log_info("[PLUGIN]: Released Python GIL after config load");
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix `plugin_driver_stop()` to check the `running` flag instead of `enabled` flag, so plugins disabled via config update while still running are properly stopped
- Remove premature `plugin_driver_init()` + `plugin_driver_start()` from boot-time in `plc_main.c` — plugins are now only started when a PLC program is loaded (in `load_plc_program`), where buffer pointers are valid
- Fix variable shadow bug and unconditional `Py_DECREF(NULL)` in `plugin_driver_stop()`

## Context

The Modbus slave plugin was spamming "Buffer read error: NULL pointer access" errors every second, even when:
1. No Modbus slave was configured for the project
2. The PLC was in STOP mode

Root cause: plugins were started at boot before any PLC program loaded buffers, and `plugin_driver_stop()` skipped plugins that had been disabled via config update (checking `enabled` flag) even though they were still running.

## Test plan

- [ ] Upload a project with Modbus slave configured, verify it works normally
- [ ] Upload a project WITHOUT Modbus slave, verify no Modbus error spam in logs
- [ ] Stop PLC, verify no plugin error messages in logs
- [ ] Start runtime fresh (no PLC program loaded), verify no plugin errors at boot
- [ ] Verify plugins still start correctly when PLC program is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)