### PR TITLE
RTOP-128: EtherCAT protocol support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Ignore generated/runtime-mutable files (same as .gitignore)
+/build*/
+/core/generated/
+/venvs/
+.venv/
+__pycache__/
+
+# Generated certificates (must be created fresh inside container)
+**/*.pem
+webserver/*.pem
+
+# Database and runtime state
+*.db
+*.socket
+*.installed
+*.log
+
+# IDE
+.vscode/
+
+# Plugin runtime configs
+plugins.conf
+core/src/drivers/plugins/python/modbus_slave/modbus_slave_config.json
+core/src/drivers/plugins/python/modbus_master/modbus_master.json
+core/src/drivers/plugins/python/opcua/opcua.json
+core/src/drivers/plugins/native/s7comm/s7comm_config.json

--- a/core/src/drivers/plugins/native/ethercat/ethercat_config.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_config.c
@@ -434,6 +434,79 @@ static int parse_slave(const cJSON *slave_json, ecat_slave_t *slave)
     parse_pdo_array(cJSON_GetObjectItemCaseSensitive(slave_json, "tx_pdos"),
                     slave->tx_pdos, &slave->tx_pdo_count);
 
+    /* Parse per-slave configuration (defaults applied if "config" is absent) */
+    slave->startup_checks.check_vendor_id = true;
+    slave->startup_checks.check_product_code = true;
+    slave->addressing.ethercat_address = 0;
+    slave->timeouts.sdo_timeout_ms = 1000;
+    slave->timeouts.init_to_preop_timeout_ms = 3000;
+    slave->timeouts.safeop_to_op_timeout_ms = 10000;
+    slave->watchdog.sm_watchdog_enabled = true;
+    slave->watchdog.sm_watchdog_ms = 100;
+    slave->watchdog.pdi_watchdog_enabled = false;
+    slave->watchdog.pdi_watchdog_ms = 100;
+    slave->dc.enabled = false;
+    slave->dc.sync_unit_cycle_us = 0;
+    slave->dc.sync0_enabled = false;
+    slave->dc.sync0_cycle_us = 0;
+    slave->dc.sync0_shift_us = 0;
+    slave->dc.sync1_enabled = false;
+    slave->dc.sync1_cycle_us = 0;
+    slave->dc.sync1_shift_us = 0;
+
+    const cJSON *cfg = cJSON_GetObjectItemCaseSensitive(slave_json, "config");
+    if (cfg != NULL && cJSON_IsObject(cfg)) {
+        /* Startup checks */
+        const cJSON *sc = cJSON_GetObjectItemCaseSensitive(cfg, "startup_checks");
+        if (sc != NULL && cJSON_IsObject(sc)) {
+            slave->startup_checks.check_vendor_id = get_bool(sc, "check_vendor_id", true);
+            slave->startup_checks.check_product_code = get_bool(sc, "check_product_code", true);
+        }
+
+        /* Addressing */
+        const cJSON *addr = cJSON_GetObjectItemCaseSensitive(cfg, "addressing");
+        if (addr != NULL && cJSON_IsObject(addr)) {
+            slave->addressing.ethercat_address = (uint16_t)get_int(addr, "ethercat_address", 0);
+        }
+
+        /* Timeouts (negative values fall back to defaults) */
+        const cJSON *to = cJSON_GetObjectItemCaseSensitive(cfg, "timeouts");
+        if (to != NULL && cJSON_IsObject(to)) {
+            int val;
+            val = get_int(to, "sdo_timeout_ms", 1000);
+            if (val > 0) slave->timeouts.sdo_timeout_ms = val;
+            val = get_int(to, "init_to_preop_timeout_ms", 3000);
+            if (val > 0) slave->timeouts.init_to_preop_timeout_ms = val;
+            val = get_int(to, "safeop_to_op_timeout_ms", 10000);
+            if (val > 0) slave->timeouts.safeop_to_op_timeout_ms = val;
+        }
+
+        /* Watchdog (negative ms values fall back to defaults) */
+        const cJSON *wd = cJSON_GetObjectItemCaseSensitive(cfg, "watchdog");
+        if (wd != NULL && cJSON_IsObject(wd)) {
+            int val;
+            slave->watchdog.sm_watchdog_enabled = get_bool(wd, "sm_watchdog_enabled", true);
+            val = get_int(wd, "sm_watchdog_ms", 100);
+            if (val > 0) slave->watchdog.sm_watchdog_ms = val;
+            slave->watchdog.pdi_watchdog_enabled = get_bool(wd, "pdi_watchdog_enabled", false);
+            val = get_int(wd, "pdi_watchdog_ms", 100);
+            if (val > 0) slave->watchdog.pdi_watchdog_ms = val;
+        }
+
+        /* Distributed Clocks */
+        const cJSON *dc = cJSON_GetObjectItemCaseSensitive(cfg, "distributed_clocks");
+        if (dc != NULL && cJSON_IsObject(dc)) {
+            slave->dc.enabled = get_bool(dc, "enabled", false);
+            slave->dc.sync_unit_cycle_us = get_int(dc, "sync_unit_cycle_us", 0);
+            slave->dc.sync0_enabled = get_bool(dc, "sync0_enabled", false);
+            slave->dc.sync0_cycle_us = get_int(dc, "sync0_cycle_us", 0);
+            slave->dc.sync0_shift_us = get_int(dc, "sync0_shift_us", 0);
+            slave->dc.sync1_enabled = get_bool(dc, "sync1_enabled", false);
+            slave->dc.sync1_cycle_us = get_int(dc, "sync1_cycle_us", 0);
+            slave->dc.sync1_shift_us = get_int(dc, "sync1_shift_us", 0);
+        }
+    }
+
     return ECAT_CONFIG_OK;
 }
 

--- a/core/src/drivers/plugins/native/ethercat/ethercat_config.h
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_config.h
@@ -114,10 +114,70 @@ typedef struct {
 } ecat_channel_t;
 
 /**
+ * @brief Per-slave startup checks
+ *
+ * Controls which identity fields are validated against the SOEM slave list
+ * during topology verification.
+ */
+typedef struct {
+    bool     check_vendor_id;
+    bool     check_product_code;
+} ecat_startup_checks_t;
+
+/**
+ * @brief Per-slave addressing
+ *
+ * Controls slave addressing on the bus.
+ */
+typedef struct {
+    uint16_t ethercat_address;    /* 0 = auto-assign */
+} ecat_addressing_t;
+
+/**
+ * @brief Per-slave timeouts
+ *
+ * Configurable timeouts for SDO operations and state transitions.
+ */
+typedef struct {
+    int      sdo_timeout_ms;           /* SDO operation timeout (default: 1000) */
+    int      init_to_preop_timeout_ms; /* INIT->PRE-OP timeout (default: 3000) */
+    int      safeop_to_op_timeout_ms;  /* SAFE-OP->OP timeout (default: 10000) */
+} ecat_timeouts_t;
+
+/**
+ * @brief Per-slave watchdog configuration
+ *
+ * Controls Sync Manager and PDI watchdog behavior per slave.
+ */
+typedef struct {
+    bool     sm_watchdog_enabled;      /* Sync Manager watchdog */
+    int      sm_watchdog_ms;           /* SM watchdog timeout (default: 100) */
+    bool     pdi_watchdog_enabled;     /* PDI watchdog */
+    int      pdi_watchdog_ms;          /* PDI watchdog timeout (default: 100) */
+} ecat_watchdog_t;
+
+/**
+ * @brief Per-slave Distributed Clocks configuration
+ *
+ * Controls DC SYNC0/SYNC1 signal generation per slave.
+ */
+typedef struct {
+    bool     enabled;
+    int      sync_unit_cycle_us;       /* 0 = use master cycle */
+    bool     sync0_enabled;
+    int      sync0_cycle_us;
+    int      sync0_shift_us;
+    bool     sync1_enabled;
+    int      sync1_cycle_us;
+    int      sync1_shift_us;
+} ecat_dc_config_t;
+
+/**
  * @brief EtherCAT slave configuration
  *
  * Complete configuration for a single EtherCAT slave device,
- * including identity, channel mappings, PDOs, and SDOs.
+ * including identity, channel mappings, PDOs, SDOs, and per-slave
+ * settings for timeouts, watchdogs, and distributed clocks.
  */
 typedef struct {
     int               position;        /* ec_slave[position] in SOEM (1-based) */
@@ -134,6 +194,11 @@ typedef struct {
     int               rx_pdo_count;
     ecat_pdo_t        tx_pdos[ECAT_MAX_PDOS];
     int               tx_pdo_count;
+    ecat_startup_checks_t startup_checks;
+    ecat_addressing_t     addressing;
+    ecat_timeouts_t       timeouts;
+    ecat_watchdog_t       watchdog;
+    ecat_dc_config_t      dc;
 } ecat_slave_t;
 
 /**

--- a/core/src/drivers/plugins/native/ethercat/ethercat_io.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_io.c
@@ -398,6 +398,19 @@ int ecat_io_build_channel_map(const ecat_config_t *config,
                 ecat_data_type_name(pdo_data_type), ch->iec_location,
                 (iec_loc.direction == IEC_DIR_INPUT) ? "INPUT" : "OUTPUT",
                 iec_loc.byte_index, iec_loc.bit_index, iomap_offset);
+
+            if (pdo_data_type == ECAT_DTYPE_REAL32 ||
+                pdo_data_type == ECAT_DTYPE_REAL64) {
+                const char *iec_type =
+                    (pdo_data_type == ECAT_DTYPE_REAL32) ? "REAL" : "LREAL";
+                plugin_logger_info(logger,
+                    "Slave '%s' channel '%s': PDO type is %s mapped to %s. "
+                    "Declare the PLC variable as %s so the IEEE 754 bit "
+                    "pattern is interpreted correctly",
+                    cfg_slave->name, ch->name,
+                    ecat_data_type_name(pdo_data_type), ch->iec_location,
+                    iec_type);
+            }
         }
     }
 

--- a/core/src/drivers/plugins/native/ethercat/ethercat_master.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_master.c
@@ -489,22 +489,36 @@ int ecat_master_validate_topology(const ecat_config_t *config, plugin_logger_t *
 
         ec_slavet *found = &g_ecx_context.slavelist[pos];
 
-        if (found->eep_man != expected->vendor_id) {
-            plugin_logger_error(logger,
-                "Slave %d (%s) at position %d: vendor_id mismatch - "
-                "expected 0x%08X, found 0x%08X",
-                i, expected->name, pos,
-                expected->vendor_id, found->eep_man);
-            return -1;
+        /* Vendor ID check (can be disabled per slave via startup_checks) */
+        if (expected->startup_checks.check_vendor_id) {
+            if (found->eep_man != expected->vendor_id) {
+                plugin_logger_error(logger,
+                    "Slave %d (%s) at position %d: vendor_id mismatch - "
+                    "expected 0x%08X, found 0x%08X",
+                    i, expected->name, pos,
+                    expected->vendor_id, found->eep_man);
+                return -1;
+            }
+        } else {
+            plugin_logger_debug(logger,
+                "Slave %d (%s) at position %d: vendor_id check disabled",
+                i, expected->name, pos);
         }
 
-        if (found->eep_id != expected->product_code) {
-            plugin_logger_error(logger,
-                "Slave %d (%s) at position %d: product_code mismatch - "
-                "expected 0x%08X, found 0x%08X",
-                i, expected->name, pos,
-                expected->product_code, found->eep_id);
-            return -1;
+        /* Product code check (can be disabled per slave via startup_checks) */
+        if (expected->startup_checks.check_product_code) {
+            if (found->eep_id != expected->product_code) {
+                plugin_logger_error(logger,
+                    "Slave %d (%s) at position %d: product_code mismatch - "
+                    "expected 0x%08X, found 0x%08X",
+                    i, expected->name, pos,
+                    expected->product_code, found->eep_id);
+                return -1;
+            }
+        } else {
+            plugin_logger_debug(logger,
+                "Slave %d (%s) at position %d: product_code check disabled",
+                i, expected->name, pos);
         }
 
         plugin_logger_debug(logger,
@@ -658,10 +672,22 @@ int ecat_master_open_and_scan(const ecat_config_t *config, plugin_logger_t *logg
     /* Step 4: Wait for all slaves to reach PRE-OP state.
      * ecx_config_init() requests PRE-OP but does not wait for the
      * transition to complete. Slaves need to be in PRE-OP before
-     * mailbox communication (SDO writes) can work. */
+     * mailbox communication (SDO writes) can work.
+     *
+     * Use the maximum init_to_preop_timeout across all configured slaves. */
     plugin_logger_info(logger, "Waiting for slaves to reach PRE-OP state...");
 
-    ecx_statecheck(&g_ecx_context, 0, EC_STATE_PRE_OP, EC_TIMEOUTSTATE * 4);
+    int max_preop_timeout_us = 0;
+    for (int i = 0; i < config->slave_count; i++) {
+        int t_us = config->slaves[i].timeouts.init_to_preop_timeout_ms * 1000;
+        if (t_us > max_preop_timeout_us)
+            max_preop_timeout_us = t_us;
+    }
+    if (max_preop_timeout_us == 0)
+        max_preop_timeout_us = EC_TIMEOUTSTATE * 4;
+    plugin_logger_debug(logger, "Using INIT->PRE-OP timeout: %d us", max_preop_timeout_us);
+
+    ecx_statecheck(&g_ecx_context, 0, EC_STATE_PRE_OP, max_preop_timeout_us);
     ecx_readstate(&g_ecx_context);
 
     int all_preop = 1;
@@ -694,7 +720,8 @@ int ecat_master_open_and_scan(const ecat_config_t *config, plugin_logger_t *logg
  */
 
 int ecat_master_write_sdos(int slave_pos, const ecat_sdo_config_t *sdos,
-                           int sdo_count, plugin_logger_t *logger)
+                           int sdo_count, int sdo_timeout_ms,
+                           plugin_logger_t *logger)
 {
     if (!g_soem_initialized) {
         plugin_logger_error(logger, "Cannot write SDOs: SOEM not initialized");
@@ -758,9 +785,12 @@ int ecat_master_write_sdos(int slave_pos, const ecat_sdo_config_t *sdos,
                 sdo->data_type, size);
         }
 
+        /* Use per-slave SDO timeout if configured, otherwise SOEM default */
+        int sdo_timeout_us = (sdo_timeout_ms > 0) ? (sdo_timeout_ms * 1000) : EC_TIMEOUTRXM;
+
         int wkc = ecx_SDOwrite(&g_ecx_context, (uint16)slave_pos,
                                 index, sdo->subindex,
-                                FALSE, size, value_buf, EC_TIMEOUTRXM);
+                                FALSE, size, value_buf, sdo_timeout_us);
 
         if (wkc <= 0) {
             plugin_logger_warn(logger,
@@ -784,6 +814,178 @@ int ecat_master_write_sdos(int slave_pos, const ecat_sdo_config_t *sdos,
  * Phase 3: Process Data Mapping + Distributed Clocks
  * =============================================================================
  */
+
+/**
+ * @brief Configure watchdog timers for a single slave via register writes.
+ *
+ * EtherCAT watchdog registers (addressed by configured address):
+ *   0x0400 (2 bytes) - Watchdog divider (default 0x09C2 = 2498)
+ *   0x0402 (2 bytes) - PDI watchdog time (in watchdog divider ticks)
+ *   0x0420 (2 bytes) - SM watchdog time  (in watchdog divider ticks)
+ *
+ * Default divider 0x09C2 = 2498 -> (2498+2)*25ns = 62.5us per tick.
+ * To set watchdog to X ms: ticks = X * 1000 / 62.5 = X * 16
+ *
+ * @param slave_pos 1-based slave position on the bus
+ * @param wd        Watchdog configuration
+ * @param logger    Plugin logger instance
+ */
+static void ecat_master_configure_watchdog(int slave_pos, const ecat_watchdog_t *wd,
+                                           plugin_logger_t *logger)
+{
+    /* Maximum watchdog timeout in ms that fits in a uint16_t register
+     * with the default divider (1 tick = 62.5 us -> ticks = ms * 16).
+     * 65535 / 16 = 4095.9 ms */
+    const int max_watchdog_ms = UINT16_MAX / 16;
+
+    uint16_t configadr = g_ecx_context.slavelist[slave_pos].configadr;
+    int wkc;
+
+    /* SM watchdog register 0x0420 - only write if explicitly enabled. */
+    if (wd->sm_watchdog_enabled) {
+        uint16_t sm_wd_ticks = 0;
+        if (wd->sm_watchdog_ms > 0) {
+            int clamped_ms = wd->sm_watchdog_ms;
+            if (clamped_ms > max_watchdog_ms) {
+                plugin_logger_warn(logger,
+                    "Slave %d: SM watchdog %d ms exceeds max %d ms, clamping",
+                    slave_pos, wd->sm_watchdog_ms, max_watchdog_ms);
+                clamped_ms = max_watchdog_ms;
+            }
+            sm_wd_ticks = (uint16_t)(clamped_ms * 16);
+        }
+        wkc = ecx_FPWR(&g_ecx_context.port, configadr, 0x0420,
+                            sizeof(sm_wd_ticks), &sm_wd_ticks, EC_TIMEOUTRET);
+        if (wkc <= 0) {
+            plugin_logger_warn(logger,
+                "Slave %d: failed to write SM watchdog register 0x0420 (wkc=%d)",
+                slave_pos, wkc);
+        } else {
+            plugin_logger_debug(logger,
+                "Slave %d: SM watchdog enabled (ticks=%u, ~%d ms)",
+                slave_pos, sm_wd_ticks, wd->sm_watchdog_ms);
+        }
+    } else {
+        plugin_logger_debug(logger,
+            "Slave %d: SM watchdog disabled, skipping register write",
+            slave_pos);
+    }
+
+    /* PDI watchdog register 0x0402 - only write if explicitly enabled,
+     * as many slaves do not support PDI watchdog and return wkc=0. */
+    if (wd->pdi_watchdog_enabled) {
+        uint16_t pdi_wd_ticks = 0;
+        if (wd->pdi_watchdog_ms > 0) {
+            int clamped_ms = wd->pdi_watchdog_ms;
+            if (clamped_ms > max_watchdog_ms) {
+                plugin_logger_warn(logger,
+                    "Slave %d: PDI watchdog %d ms exceeds max %d ms, clamping",
+                    slave_pos, wd->pdi_watchdog_ms, max_watchdog_ms);
+                clamped_ms = max_watchdog_ms;
+            }
+            pdi_wd_ticks = (uint16_t)(clamped_ms * 16);
+        }
+        wkc = ecx_FPWR(&g_ecx_context.port, configadr, 0x0402,
+                        sizeof(pdi_wd_ticks), &pdi_wd_ticks, EC_TIMEOUTRET);
+        if (wkc <= 0) {
+            plugin_logger_warn(logger,
+                "Slave %d: failed to write PDI watchdog register 0x0402 (wkc=%d)",
+                slave_pos, wkc);
+        } else {
+            plugin_logger_debug(logger,
+                "Slave %d: PDI watchdog enabled (ticks=%u, ~%d ms)",
+                slave_pos, pdi_wd_ticks, wd->pdi_watchdog_ms);
+        }
+    } else {
+        plugin_logger_debug(logger,
+            "Slave %d: PDI watchdog disabled, skipping register write",
+            slave_pos);
+    }
+}
+
+/**
+ * @brief Configure Distributed Clocks per slave based on JSON configuration.
+ *
+ * First calls ecx_configdc() to discover DC-capable slaves and measure
+ * propagation delays.  Then for each slave with dc.enabled, configures
+ * SYNC0 and/or SYNC1 signals.
+ *
+ * @param config Parsed EtherCAT configuration
+ * @param logger Plugin logger instance
+ */
+static void ecat_master_configure_dc(const ecat_config_t *config, plugin_logger_t *logger)
+{
+    /* Step 1: Let SOEM discover DC-capable slaves and measure delays */
+    plugin_logger_info(logger, "Configuring Distributed Clocks...");
+    ecx_configdc(&g_ecx_context);
+
+    /* Step 2: Apply per-slave DC configuration */
+    for (int i = 0; i < config->slave_count; i++) {
+        const ecat_slave_t *slave = &config->slaves[i];
+        int pos = slave->position;
+
+        if (!slave->dc.enabled)
+            continue;
+
+        if (pos < 1 || pos > g_ecx_context.slavecount) {
+            plugin_logger_warn(logger,
+                "Slave %d (%s): DC config skipped - position out of range",
+                pos, slave->name);
+            continue;
+        }
+
+        if (!g_ecx_context.slavelist[pos].hasdc) {
+            plugin_logger_warn(logger,
+                "Slave %d (%s): DC config requested but slave has no DC support",
+                pos, slave->name);
+            continue;
+        }
+
+        /* Determine cycle time: use slave-specific or fall back to master cycle */
+        uint32_t cycle_ns;
+        if (slave->dc.sync_unit_cycle_us > 0) {
+            cycle_ns = (uint32_t)(slave->dc.sync_unit_cycle_us * 1000);
+        } else {
+            cycle_ns = (uint32_t)(config->master.cycle_time_us * 1000);
+        }
+
+        if (slave->dc.sync0_enabled && slave->dc.sync1_enabled) {
+            /* Both SYNC0 and SYNC1 */
+            uint32_t cycle0_ns = (slave->dc.sync0_cycle_us > 0)
+                ? (uint32_t)(slave->dc.sync0_cycle_us * 1000) : cycle_ns;
+            uint32_t cycle1_ns = (slave->dc.sync1_cycle_us > 0)
+                ? (uint32_t)(slave->dc.sync1_cycle_us * 1000) : cycle_ns;
+            int32_t shift_ns = (int32_t)(slave->dc.sync0_shift_us * 1000);
+
+            ecx_dcsync01(&g_ecx_context, (uint16)pos, TRUE,
+                         cycle0_ns, cycle1_ns, shift_ns);
+
+            plugin_logger_info(logger,
+                "Slave %d (%s): DC SYNC0+SYNC1 enabled "
+                "(cycle0=%u ns, cycle1=%u ns, shift=%d ns)",
+                pos, slave->name, cycle0_ns, cycle1_ns, shift_ns);
+
+        } else if (slave->dc.sync0_enabled) {
+            /* SYNC0 only */
+            uint32_t sync0_ns = (slave->dc.sync0_cycle_us > 0)
+                ? (uint32_t)(slave->dc.sync0_cycle_us * 1000) : cycle_ns;
+            int32_t shift_ns = (int32_t)(slave->dc.sync0_shift_us * 1000);
+
+            ecx_dcsync0(&g_ecx_context, (uint16)pos, TRUE,
+                        sync0_ns, shift_ns);
+
+            plugin_logger_info(logger,
+                "Slave %d (%s): DC SYNC0 enabled (cycle=%u ns, shift=%d ns)",
+                pos, slave->name, sync0_ns, shift_ns);
+
+        } else {
+            /* DC enabled but no SYNC signals - just log it */
+            plugin_logger_debug(logger,
+                "Slave %d (%s): DC enabled but no SYNC signals configured",
+                pos, slave->name);
+        }
+    }
+}
 
 int ecat_master_configure(const ecat_config_t *config, plugin_logger_t *logger)
 {
@@ -812,9 +1014,18 @@ int ecat_master_configure(const ecat_config_t *config, plugin_logger_t *logger)
     plugin_logger_info(logger, "IO map: %d output bytes, %d input bytes, %d segments",
                        grp->Obytes, grp->Ibytes, grp->nsegments);
 
-    /* Step 5: Configure Distributed Clocks */
-    plugin_logger_info(logger, "Configuring Distributed Clocks...");
-    ecx_configdc(&g_ecx_context);
+    /* Step 5: Configure watchdogs per slave */
+    plugin_logger_info(logger, "Configuring per-slave watchdogs...");
+    for (int i = 0; i < config->slave_count; i++) {
+        const ecat_slave_t *slave = &config->slaves[i];
+        int pos = slave->position;
+        if (pos >= 1 && pos <= g_ecx_context.slavecount) {
+            ecat_master_configure_watchdog(pos, &slave->watchdog, logger);
+        }
+    }
+
+    /* Step 6: Configure Distributed Clocks per slave */
+    ecat_master_configure_dc(config, logger);
 
     return 0;
 }
@@ -825,17 +1036,30 @@ int ecat_master_configure(const ecat_config_t *config, plugin_logger_t *logger)
  * =============================================================================
  */
 
-int ecat_master_transition_to_op(plugin_logger_t *logger)
+int ecat_master_transition_to_op(const ecat_config_t *config, plugin_logger_t *logger)
 {
     if (!g_soem_initialized) {
         plugin_logger_error(logger, "Cannot transition: SOEM not initialized");
         return -1;
     }
 
+    /* Compute maximum SAFE-OP->OP timeout across all configured slaves */
+    int max_safeop_timeout_us = 0;
+    if (config != NULL) {
+        for (int i = 0; i < config->slave_count; i++) {
+            int t_us = config->slaves[i].timeouts.safeop_to_op_timeout_ms * 1000;
+            if (t_us > max_safeop_timeout_us)
+                max_safeop_timeout_us = t_us;
+        }
+    }
+    if (max_safeop_timeout_us == 0)
+        max_safeop_timeout_us = EC_TIMEOUTSTATE * 4;
+
     /* Step 6: Wait for SAFE_OP after config */
     plugin_logger_info(logger, "Waiting for SAFE_OP state...");
+    plugin_logger_debug(logger, "Using SAFE-OP->OP timeout: %d us", max_safeop_timeout_us);
 
-    ecx_statecheck(&g_ecx_context, 0, EC_STATE_SAFE_OP, EC_TIMEOUTSTATE * 4);
+    ecx_statecheck(&g_ecx_context, 0, EC_STATE_SAFE_OP, max_safeop_timeout_us);
 
     /* Read back actual states */
     ecx_readstate(&g_ecx_context);
@@ -872,11 +1096,14 @@ int ecat_master_transition_to_op(plugin_logger_t *logger)
 
     /* Poll for OP state with process data exchange between checks */
     int op_reached = 0;
+    int poll_timeout_us = max_safeop_timeout_us / ECAT_OP_POLL_RETRIES;
+    if (poll_timeout_us < EC_TIMEOUTRET)
+        poll_timeout_us = EC_TIMEOUTRET;
+
     for (int retry = 0; retry < ECAT_OP_POLL_RETRIES; retry++) {
         ecx_send_processdata(&g_ecx_context);
         ecx_receive_processdata(&g_ecx_context, EC_TIMEOUTRET);
-        ecx_statecheck(&g_ecx_context, 0, EC_STATE_OPERATIONAL,
-                        EC_TIMEOUTSTATE / ECAT_OP_POLL_RETRIES);
+        ecx_statecheck(&g_ecx_context, 0, EC_STATE_OPERATIONAL, poll_timeout_us);
 
         if (g_ecx_context.slavelist[0].state == EC_STATE_OPERATIONAL) {
             op_reached = 1;

--- a/core/src/drivers/plugins/native/ethercat/ethercat_master.h
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_master.h
@@ -43,14 +43,16 @@ int ecat_master_open_and_scan(const ecat_config_t *config, plugin_logger_t *logg
  * Must be called while slaves are in PRE-OP state (after open_and_scan,
  * before configure).
  *
- * @param slave_pos  1-based slave position on the bus
- * @param sdos       Array of SDO configuration entries
- * @param sdo_count  Number of SDO entries
- * @param logger     Plugin logger instance
+ * @param slave_pos      1-based slave position on the bus
+ * @param sdos           Array of SDO configuration entries
+ * @param sdo_count      Number of SDO entries
+ * @param sdo_timeout_ms SDO operation timeout in milliseconds (0 = SOEM default)
+ * @param logger         Plugin logger instance
  * @return Number of SDOs successfully written, or -1 on critical error
  */
 int ecat_master_write_sdos(int slave_pos, const ecat_sdo_config_t *sdos,
-                           int sdo_count, plugin_logger_t *logger);
+                           int sdo_count, int sdo_timeout_ms,
+                           plugin_logger_t *logger);
 
 /**
  * @brief Map process data and configure Distributed Clocks
@@ -72,10 +74,14 @@ int ecat_master_configure(const ecat_config_t *config, plugin_logger_t *logger);
  *   6. Wait for SAFE_OP state
  *   7. Request and poll for OPERATIONAL state
  *
+ * Uses per-slave safeop_to_op_timeout_ms from the configuration (the
+ * maximum across all slaves is applied to the broadcast statecheck).
+ *
+ * @param config Parsed EtherCAT configuration (for per-slave timeouts)
  * @param logger Plugin logger instance
  * @return 0 on success, -1 on failure
  */
-int ecat_master_transition_to_op(plugin_logger_t *logger);
+int ecat_master_transition_to_op(const ecat_config_t *config, plugin_logger_t *logger);
 
 /**
  * @brief Validate bus topology against configuration

--- a/core/src/drivers/plugins/native/ethercat/ethercat_plugin.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_plugin.c
@@ -538,7 +538,8 @@ int start_loop(void)
         const ecat_slave_t *slave = &g_config.slaves[i];
         if (slave->sdo_count > 0) {
             ecat_master_write_sdos(slave->position, slave->sdo_configs,
-                                   slave->sdo_count, &g_logger);
+                                   slave->sdo_count,
+                                   slave->timeouts.sdo_timeout_ms, &g_logger);
         }
     }
 
@@ -570,7 +571,7 @@ int start_loop(void)
     atomic_store(&g_plugin_state, ECAT_STATE_TRANSITIONING);
     plugin_logger_info(&g_logger, "[state: TRANSITIONING] Moving slaves to OPERATIONAL...");
 
-    if (ecat_master_transition_to_op(&g_logger) != 0) {
+    if (ecat_master_transition_to_op(&g_config, &g_logger) != 0) {
         plugin_logger_error(&g_logger, "Failed to reach OPERATIONAL state");
         ecat_master_close(&g_logger);
         atomic_store(&g_plugin_state, ECAT_STATE_ERROR);

--- a/core/src/drivers/plugins/native/ethercat/ethercat_plugin.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_plugin.c
@@ -149,8 +149,8 @@ static pthread_mutex_t g_status_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Diagnostics (updated by cycle_start in the PLC thread) */
 static ecat_cycle_diag_t g_diag;
-static int g_consecutive_wkc_errors = 0;
-static int g_recovery_attempts = 0;
+static _Atomic(int) g_consecutive_wkc_errors = 0;
+static _Atomic(int) g_recovery_attempts = 0;
 static uint64_t g_cycle_counter = 0;
 
 #if ECAT_ENABLE_MONITOR_THREAD
@@ -305,11 +305,30 @@ static int attempt_recovery(void)
  * The PLC thread checks this flag at the top of cycle_start() and, when set,
  * skips the SOEM exchange and signals g_soem_paused.
  *
+ * The paused flag is cleared before requesting to prevent a stale
+ * acknowledgment from a previous release/request window from being
+ * misinterpreted as a fresh yield. Without this, the following race
+ * can occur:
+ *
+ *   1. release_soem_access() stores pause_requested=false
+ *   2. PLC cycle_start() sees the (not-yet-cleared) pause_requested=true,
+ *      sets paused=true, and skips the exchange
+ *   3. release_soem_access() stores paused=false -- but step 2 already
+ *      overwrote it back to true
+ *   4. On the next monitor interval, request_soem_access() sees the
+ *      stale paused=true and returns immediately, even though the PLC
+ *      thread is actively using SOEM
+ *
+ * Clearing paused first ensures we only succeed when the PLC thread
+ * acknowledges *this* specific request.
+ *
  * @param timeout_ms Maximum time to wait for PLC thread acknowledgment
  * @return true if SOEM access was granted, false on timeout
  */
 static bool request_soem_access(int timeout_ms)
 {
+    /* Clear any stale acknowledgment before raising a new request */
+    atomic_store(&g_soem_paused, false);
     atomic_store(&g_soem_pause_requested, true);
 
     struct timespec ts = { 0, 1000000 }; /* 1 ms poll interval */
@@ -328,11 +347,16 @@ static bool request_soem_access(int timeout_ms)
 
 /**
  * @brief Release exclusive SOEM access, allowing PLC thread to resume exchange
+ *
+ * The request flag is cleared first so that the PLC thread stops yielding
+ * before the acknowledgment flag is reset.  This prevents a PLC cycle
+ * that lands between the two stores from re-setting paused=true (which
+ * would leave a stale acknowledgment for the next request_soem_access).
  */
 static void release_soem_access(void)
 {
-    atomic_store(&g_soem_paused, false);
     atomic_store(&g_soem_pause_requested, false);
+    atomic_store(&g_soem_paused, false);
 }
 
 /*

--- a/install.sh
+++ b/install.sh
@@ -188,7 +188,8 @@ install_deps_apt() {
         cmake \
         pkg-config \
         libffi-dev \
-        ethtool
+        ethtool \
+        git
 }
 
 # For yum-based distros (RHEL 7, CentOS 7, Amazon Linux)

--- a/install.sh
+++ b/install.sh
@@ -177,6 +177,39 @@ install_dependencies()
     fi
 }
 
+CMAKE_MIN_VERSION="3.28"
+
+install_cmake() {
+    # Check if system cmake already meets the minimum version
+    if command -v cmake >/dev/null 2>&1; then
+        local current_version
+        current_version=$(cmake --version | head -1 | grep -oP '[0-9]+\.[0-9]+(\.[0-9]+)?')
+        if printf '%s\n%s\n' "$CMAKE_MIN_VERSION" "$current_version" | sort -V | head -1 | grep -qx "$CMAKE_MIN_VERSION"; then
+            echo "CMake $current_version already meets minimum requirement ($CMAKE_MIN_VERSION)"
+            return 0
+        fi
+        echo "CMake $current_version is too old (need $CMAKE_MIN_VERSION+), installing newer version..."
+    fi
+
+    local arch
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64)  arch="x86_64" ;;
+        aarch64) arch="aarch64" ;;
+        *)
+            echo "WARNING: No prebuilt CMake binary for $arch, falling back to pip"
+            pip3 install --break-system-packages cmake
+            return $?
+            ;;
+    esac
+
+    local cmake_version="3.31.6"
+    local cmake_url="https://github.com/Kitware/CMake/releases/download/v${cmake_version}/cmake-${cmake_version}-linux-${arch}.tar.gz"
+    echo "Installing CMake ${cmake_version} from official release..."
+    curl -fsSL "$cmake_url" | tar xz -C /usr/local --strip-components=1
+    echo "CMake $(cmake --version | head -1) installed"
+}
+
 # For apt-based distros (Debian, Ubuntu, Linux Mint, Pop!_OS, elementary OS, Zorin, MX Linux, etc.)
 install_deps_apt() {
     apt-get update && \
@@ -185,11 +218,15 @@ install_deps_apt() {
         python3-dev python3-pip python3-venv \
         gcc \
         make \
-        cmake \
         pkg-config \
         libffi-dev \
         ethtool \
-        git
+        git \
+        ca-certificates \
+        curl
+    # Install CMake 3.28+ (required by SOEM/EtherCAT plugin)
+    # Debian Bookworm only ships 3.25 which is too old
+    install_cmake
 }
 
 # For yum-based distros (RHEL 7, CentOS 7, Amazon Linux)

--- a/plugins_default.conf
+++ b/plugins_default.conf
@@ -2,3 +2,4 @@ modbus_slave,./core/src/drivers/plugins/python/modbus_slave/simple_modbus.py,0,0
 modbus_master,./core/src/drivers/plugins/python/modbus_master/modbus_master_plugin.py,0,0,./core/src/drivers/plugins/python/modbus_master/modbus_master.json,./venvs/modbus_master
 opcua,./core/src/drivers/plugins/python/opcua/plugin.py,0,0,./core/src/drivers/plugins/python/opcua/opcua.json,./venvs/opcua
 s7comm,./build/plugins/libs7comm_plugin.so,0,1,./core/src/drivers/plugins/native/s7comm/s7comm_config.json,
+ethercat,./build/plugins/libethercat_plugin.so,0,1,./core/src/drivers/plugins/native/ethercat/ethercat_config.json,


### PR DESCRIPTION
## Summary
- Register EtherCAT native plugin in `plugins_default.conf` and add `.dockerignore` for Docker build optimization
- Fix build dependencies: install `git` for submodule init and CMake 3.28+ for SOEM compatibility
- Fix race conditions in cooperative SOEM access protocol between PLC and monitor threads
- Add per-slave configurable timeouts (SDO, INIT->PRE-OP, SAFE-OP->OP) via JSON configuration
- Add per-slave SM and PDI watchdog control with uint16 overflow protection; register writes gated by enabled flag to avoid wkc=0 on unsupported slaves
- Add per-slave Distributed Clocks configuration (SYNC0/SYNC1)
- Add optional vendor_id and product_code startup check bypass
- Add info log for REAL32/REAL64 PDO channels advising correct PLC variable type declaration

## Test plan
- [x] Verify EtherCAT plugin is loaded on runtime startup
- [x] Confirm Docker builds succeed with new `.dockerignore`
- [x] Validate CMake version and git availability during `install.sh`
- [x] Verify configurable timeouts are applied (check debug logs for timeout values)
- [x] Verify SM watchdog register writes succeed on supported slaves (e.g. Beckhoff EL2809)
- [x] Verify PDI watchdog register write is skipped when `pdi_watchdog_enabled: false` (default)
- [x] Verify PDI watchdog register write is attempted only when explicitly enabled
- [x] Test watchdog ms values > 4095 are clamped with warning log
- [x] Test negative timeout/watchdog values in JSON fall back to defaults
- [x] Verify startup_checks bypass works (disable vendor_id/product_code checks)
- [x] Verify REAL32/REAL64 PDO channels produce info log about PLC type declaration