### PR TITLE
fix: Robust plugin stop sequence with non-blocking socket commands

### DIFF
--- a/core/src/drivers/plugin_driver.c
+++ b/core/src/drivers/plugin_driver.c
@@ -461,6 +461,8 @@ int plugin_driver_stop(plugin_driver_t *driver)
         return 0;
     }
 
+    int stop_failed = 0;
+
     // Only acquire Python GIL if we have Python plugins and Python is initialized
     PyGILState_STATE local_gstate;
     int need_gil = has_python_plugin && Py_IsInitialized();
@@ -489,11 +491,21 @@ int plugin_driver_stop(plugin_driver_t *driver)
             {
                 PyErr_Print();
                 log_error("Python stop call failed for plugin: %s", plugin->config.name);
+                stop_failed = 1;
             }
             else
             {
-                log_info("Plugin %s stopped successfully", plugin->config.name);
+                int success = PyObject_IsTrue(res);
                 Py_DECREF(res);
+                if (success == 1)
+                {
+                    log_info("Plugin %s stopped successfully", plugin->config.name);
+                }
+                else
+                {
+                    log_error("Plugin %s failed to stop cleanly", plugin->config.name);
+                    stop_failed = 1;
+                }
             }
             plugin->running = 0;
         }
@@ -510,7 +522,7 @@ int plugin_driver_stop(plugin_driver_t *driver)
         PyGILState_Release(local_gstate);
     }
 
-    return 0;
+    return stop_failed ? -1 : 0;
 }
 
 void plugin_driver_destroy(plugin_driver_t *driver)

--- a/core/src/drivers/plugins/python/modbus_master/modbus_master_plugin.py
+++ b/core/src/drivers/plugins/python/modbus_master/modbus_master_plugin.py
@@ -993,6 +993,9 @@ def stop_loop():
     """
     Stop the main loop and all running device threads.
     This function is called when the plugin needs to be stopped.
+
+    Returns:
+        True if all threads stopped, False if any thread survived the timeout.
     """
     global slave_threads, logger  # pylint: disable=global-variable-not-assigned
 
@@ -1013,20 +1016,24 @@ def stop_loop():
             except Exception as e:
                 logger.error(f"Error stopping thread {thread.name}: {e}")
 
-        # Wait for all threads to finish (with timeout)
-        timeout_per_thread = 5.0  # seconds
+        # Wait for all threads to finish under a shared deadline so total
+        # wall-clock time is bounded regardless of how many threads exist.
+        deadline = time.time() + 10.0
+        any_alive = False
         for thread in slave_threads:
+            remaining = max(0, deadline - time.time())
             try:
-                thread.join(timeout=timeout_per_thread)
+                thread.join(timeout=remaining)
                 if thread.is_alive():
-                    logger.warn(f"Thread {thread.name} did not stop within timeout")
+                    logger.error(f"Thread {thread.name} did not stop within timeout")
+                    any_alive = True
                 else:
                     logger.info(f"Thread {thread.name} stopped successfully")
             except Exception as e:
                 logger.error(f"Error joining thread {thread.name}: {e}")
 
         logger.info("Main loop stopped")
-        return True
+        return not any_alive
 
     except Exception as e:
         logger.error(f"Error stopping main loop: {e}")

--- a/core/src/drivers/plugins/python/modbus_slave/simple_modbus.py
+++ b/core/src/drivers/plugins/python/modbus_slave/simple_modbus.py
@@ -1221,24 +1221,49 @@ def start_loop():
         return False
 
 
+def _cancel_all_tasks(loop):
+    """Cancel all running tasks on the event loop."""
+    for task in asyncio.all_tasks(loop):
+        task.cancel()
+
+
 def stop_loop():
-    """Stop the Modbus server gracefully."""
+    """Stop the Modbus server gracefully.
+
+    Uses a two-phase approach:
+    1. Graceful (10s): call ServerStop and wait for the thread to finish.
+    2. Forced (5s): cancel all asyncio tasks on the event loop and wait again.
+
+    Returns:
+        True if the server thread stopped, False if it survived both phases.
+    """
     global server_task, running
 
     running = False
 
     if server_task:
-        # Call ServerStop() directly - it's designed for cross-thread use
-        # (uses asyncio.run_coroutine_threadsafe internally)
+        # Phase 1: Graceful stop via pymodbus ServerStop
         try:
             ServerStop()
         except RuntimeError as e:
             # Server may not be running or already stopped
             logger.warn(f"ServerStop warning: {e}")
 
-        server_task.join(timeout=5.0)
+        server_task.join(timeout=10.0)
+
         if server_task.is_alive():
-            logger.warn("Server thread did not stop within timeout")
+            # Phase 2: Force-cancel the event loop
+            logger.warn("Graceful stop timed out, forcing event loop cancellation...")
+            loop = server_loop
+            if loop is not None and loop.is_running():
+                loop.call_soon_threadsafe(_cancel_all_tasks, loop)
+            server_task.join(timeout=5.0)
+
+        if server_task.is_alive():
+            logger.error("Server thread did not stop after forced cancellation")
+            server_task = None
+            return False
+
         server_task = None
 
     logger.info("Server stopped")

--- a/core/src/drivers/plugins/python/opcua/plugin.py
+++ b/core/src/drivers/plugins/python/opcua/plugin.py
@@ -10,9 +10,9 @@ This module provides the plugin interface required by the OpenPLC runtime:
 This is a thin entry point that delegates to the modular components.
 """
 
-import sys
-import os
 import asyncio
+import os
+import sys
 import threading
 from typing import Optional
 
@@ -36,13 +36,13 @@ from shared.plugin_config_decode.opcua_config_model import OpcuaConfig
 # Import local modules (use absolute imports for runtime compatibility)
 try:
     # Try relative imports first (when loaded as package)
-    from .opcua_logging import get_logger, log_debug, log_error, log_info, log_warn
     from .config import load_config
+    from .opcua_logging import get_logger, log_debug, log_error, log_info, log_warn
     from .server import OpcuaServerManager
 except ImportError:
     # Fall back to absolute imports (when loaded directly by runtime)
-    from opcua_logging import get_logger, log_debug, log_error, log_info, log_warn
     from config import load_config
+    from opcua_logging import get_logger, log_debug, log_error, log_info, log_warn
     from server import OpcuaServerManager
 
 
@@ -53,6 +53,7 @@ _config: Optional[OpcuaConfig] = None
 _server_manager: Optional[OpcuaServerManager] = None
 _server_thread: Optional[threading.Thread] = None
 _stop_event = threading.Event()
+_loop: Optional[asyncio.AbstractEventLoop] = None
 
 
 def init(args_capsule) -> bool:
@@ -138,9 +139,7 @@ def start_loop() -> bool:
 
         # Start server in background thread
         _server_thread = threading.Thread(
-            target=_run_server_thread,
-            daemon=True,
-            name="opcua-server"
+            target=_run_server_thread, daemon=True, name="opcua-server"
         )
         _server_thread.start()
 
@@ -155,33 +154,44 @@ def start_loop() -> bool:
 def stop_loop() -> bool:
     """
     Stop the OPC UA server.
-    
-    Called when the plugin needs to be stopped.
-    
+
+    Uses a two-phase approach:
+    1. Graceful (10s): signal the stop event and wait for the async server to
+       shut down cleanly via its monitor task.
+    2. Forced (5s): if the thread is still alive, cancel all asyncio tasks on
+       the event loop and wait again.
+
     Returns:
-        True if server stopped successfully, False otherwise
+        True if the server thread stopped, False if it survived both phases.
     """
     global _server_thread
-    
+
     log_info("Stopping OPC UA server...")
-    
+
     try:
-        # Signal stop
+        # Phase 1: Graceful stop -- signal and wait
         _stop_event.set()
-        
-        # Wait for thread to finish
+
         if _server_thread and _server_thread.is_alive():
+            _server_thread.join(timeout=10.0)
+
+        if _server_thread and _server_thread.is_alive():
+            # Phase 2: Force-cancel the asyncio event loop
+            log_warn("Graceful stop timed out, forcing event loop cancellation...")
+            loop = _loop
+            if loop is not None and loop.is_running():
+                loop.call_soon_threadsafe(_cancel_all_tasks, loop)
             _server_thread.join(timeout=5.0)
-            
-            if _server_thread.is_alive():
-                log_warn("Server thread did not stop within timeout")
-            else:
-                log_debug("Server thread stopped")
-        
+
+        if _server_thread and _server_thread.is_alive():
+            log_error("OPC UA server thread did not stop after forced cancellation")
+            _server_thread = None
+            return False
+
         _server_thread = None
         log_info("OPC UA server stopped")
         return True
-        
+
     except Exception as e:
         log_error(f"Error stopping server: {e}")
         return False
@@ -190,55 +200,71 @@ def stop_loop() -> bool:
 def cleanup() -> bool:
     """
     Clean up plugin resources.
-    
+
     Called when the plugin is being unloaded.
-    
+
     Returns:
         True if cleanup successful, False otherwise
     """
     global _runtime_args, _buffer_accessor, _config, _server_manager, _server_thread
-    
+
     log_info("Cleaning up OPC UA plugin...")
-    
+
     try:
         # Stop server if running
         stop_loop()
-        
+
         # Clear references
         _runtime_args = None
         _buffer_accessor = None
         _config = None
         _server_manager = None
         _server_thread = None
-        
+
         log_info("Cleanup completed")
         return True
-        
+
     except Exception as e:
         log_error(f"Cleanup error: {e}")
         return False
 
 
+def _cancel_all_tasks(loop):
+    """Cancel all running tasks on the event loop.
+
+    Intended to be called from stop_loop() via loop.call_soon_threadsafe().
+    """
+    for task in asyncio.all_tasks(loop):
+        task.cancel()
+
+
 def _run_server_thread() -> None:
     """
     Server thread main function.
-    
-    Runs the async server in a new event loop.
+
+    Runs the async server in a new event loop and stores a reference to the
+    loop so that stop_loop() can force-cancel tasks if the graceful shutdown
+    times out.
     """
+    global _loop
+
     async def _run_with_stop_check():
         """Run server with stop event monitoring."""
+        global _loop
+        _loop = asyncio.get_running_loop()
+
         # Create stop monitoring task
         async def _monitor_stop():
             while not _stop_event.is_set():
                 await asyncio.sleep(0.1)
-            
+
             # Stop requested
             if _server_manager:
                 await _server_manager.stop()
-        
+
         # Run server and stop monitor concurrently
         monitor_task = asyncio.create_task(_monitor_stop())
-        
+
         try:
             await _server_manager.run()
         except asyncio.CancelledError:
@@ -249,13 +275,15 @@ def _run_server_thread() -> None:
                 await monitor_task
             except asyncio.CancelledError:
                 pass
-    
+
     try:
         asyncio.run(_run_with_stop_check())
     except Exception as e:
         log_error(f"Server thread error: {e}")
+    finally:
+        _loop = None
 
 
 # For backwards compatibility, also export as module-level functions
 # that match the old plugin interface
-__all__ = ['init', 'start_loop', 'stop_loop', 'cleanup']
+__all__ = ["init", "start_loop", "stop_loop", "cleanup"]

--- a/core/src/plc_app/unix_socket.c
+++ b/core/src/plc_app/unix_socket.c
@@ -27,6 +27,52 @@ void unix_socket_set_plugin_driver(void *driver)
     g_plugin_driver = (plugin_driver_t *)driver;
 }
 
+// Flag to prevent overlapping state transitions (e.g. START while STOP is in progress).
+// Set before spawning the transition thread, cleared when the transition completes.
+static atomic_int is_transitioning = 0;
+
+static void *transition_worker(void *arg)
+{
+    PLCState target = *(PLCState *)arg;
+    free(arg);
+
+    bool result = plc_set_state(target);
+    if (!result)
+    {
+        log_error("State transition to %s failed",
+                  target == PLC_STATE_RUNNING ? "RUNNING" : "STOPPED");
+    }
+
+    atomic_store(&is_transitioning, 0);
+    return NULL;
+}
+
+// Start a background thread that performs the (potentially slow) state transition.
+// Returns true if the thread was spawned, false on error.
+static bool begin_transition(PLCState target)
+{
+    PLCState *arg = malloc(sizeof(PLCState));
+    if (!arg)
+    {
+        log_error("Failed to allocate transition argument");
+        return false;
+    }
+    *arg = target;
+
+    atomic_store(&is_transitioning, 1);
+
+    pthread_t tid;
+    if (pthread_create(&tid, NULL, transition_worker, arg) != 0)
+    {
+        log_error("Failed to create transition thread: %s", strerror(errno));
+        free(arg);
+        atomic_store(&is_transitioning, 0);
+        return false;
+    }
+    pthread_detach(tid);
+    return true;
+}
+
 // helper: read one line terminated by '\n' from a socket
 static ssize_t read_line(int fd, char *buffer, size_t max_length)
 {
@@ -49,49 +95,78 @@ static ssize_t read_line(int fd, char *buffer, size_t max_length)
     return total_read;
 }
 
+static void format_status_response(char *response, size_t response_size)
+{
+    PLCState current_state = plc_get_state();
+
+    if (current_state == PLC_STATE_INIT)
+        strncpy(response, "STATUS:INIT\n", response_size);
+    else if (current_state == PLC_STATE_RUNNING)
+        strncpy(response, "STATUS:RUNNING\n", response_size);
+    else if (current_state == PLC_STATE_STOPPED)
+        strncpy(response, "STATUS:STOPPED\n", response_size);
+    else if (current_state == PLC_STATE_ERROR)
+        strncpy(response, "STATUS:ERROR\n", response_size);
+    else if (current_state == PLC_STATE_EMPTY)
+        strncpy(response, "STATUS:EMPTY\n", response_size);
+    else
+        strncpy(response, "STATUS:UNKNOWN\n", response_size);
+}
+
 void handle_unix_socket_commands(const char *command, char *response, size_t response_size)
 {
+    // While a state transition is in progress, only allow PING and STATUS.
+    // Everything else gets COMMAND:BUSY so commands cannot overlap.
+    if (atomic_load(&is_transitioning))
+    {
+        if (strcmp(command, "PING") == 0)
+        {
+            strncpy(response, "PING:OK\n", response_size);
+        }
+        else if (strcmp(command, "STATUS") == 0)
+        {
+            format_status_response(response, response_size);
+        }
+        else
+        {
+            strncpy(response, "COMMAND:BUSY\n", response_size);
+        }
+        response[response_size - 1] = '\0';
+        return;
+    }
+
     if (strcmp(command, "PING") == 0)
     {
         strncpy(response, "PING:OK\n", response_size);
     }
     else if (strcmp(command, "STATUS") == 0)
     {
-        PLCState current_state = plc_get_state();
-
-        if (current_state == PLC_STATE_INIT)
-            strncpy(response, "STATUS:INIT\n", response_size);
-        else if (current_state == PLC_STATE_RUNNING)
-            strncpy(response, "STATUS:RUNNING\n", response_size);
-        else if (current_state == PLC_STATE_STOPPED)
-            strncpy(response, "STATUS:STOPPED\n", response_size);
-        else if (current_state == PLC_STATE_ERROR)
-            strncpy(response, "STATUS:ERROR\n", response_size);
-        else if (current_state == PLC_STATE_EMPTY)
-            strncpy(response, "STATUS:EMPTY\n", response_size);
-        else
-            strncpy(response, "STATUS:UNKNOWN\n", response_size);
+        format_status_response(response, response_size);
     }
     else if (strcmp(command, "STOP") == 0)
     {
-        if (plc_set_state(PLC_STATE_STOPPED))
-            strncpy(response, "STOP:OK\n", response_size);
+        PLCState current_state = plc_get_state();
+        if (current_state == PLC_STATE_RUNNING)
+        {
+            if (begin_transition(PLC_STATE_STOPPED))
+                strncpy(response, "STOP:OK\n", response_size);
+            else
+                strncpy(response, "STOP:ERROR\n", response_size);
+        }
         else
+        {
             strncpy(response, "STOP:ERROR\n", response_size);
+        }
     }
     else if (strcmp(command, "START") == 0)
     {
         PLCState current_state = plc_get_state();
         if (current_state != PLC_STATE_RUNNING)
         {
-            if (plc_set_state(PLC_STATE_RUNNING))
-            {
+            if (begin_transition(PLC_STATE_RUNNING))
                 strncpy(response, "START:OK\n", response_size);
-            }
             else
-            {
                 strncpy(response, "START:ERROR\n", response_size);
-            }
         }
         else
         {


### PR DESCRIPTION
## Summary

- **Non-blocking STOP/START**: The unix socket handler now responds immediately and runs state transitions in a background thread. An atomic `is_transitioning` flag rejects overlapping commands with `COMMAND:BUSY`.
- **Two-phase plugin stop**: OPC UA and Modbus Slave plugins use a 10s graceful stop followed by a 5s forced asyncio event loop cancellation. Returns `False` if the thread survives both phases.
- **Honest return values**: All three Python plugins (OPC UA, Modbus Slave, Modbus Master) now return `False` when threads fail to stop, instead of always returning `True`. The C plugin driver checks this via `PyObject_IsTrue()` and propagates failures.

## Context

When stopping the PLC within a few seconds of starting, the OPC UA plugin's async server thread hadn't finished initializing. `stop_loop()` waited 5s, gave up, returned `True` anyway, and the runtime tore down resources. The orphaned thread then accessed freed memory, crashed the C process, and the webserver's monitor auto-restarted it into RUNNING mode.

## Test plan

- [ ] Build on Linux target (`mkdir -p build && cd build && cmake .. && make`)
- [ ] Start runtime with OPC UA + Modbus plugins enabled
- [ ] Stop within 2 seconds of starting -- verify clean STOPPED state, no crash/restart
- [ ] Verify `STOP:OK` response arrives immediately (not after 10-15s)
- [ ] Send START during an in-progress STOP -- verify `COMMAND:BUSY` response
- [ ] Normal start/stop cycle still works correctly
- [ ] Check logs show either graceful or forced plugin stop, never "died unexpectedly"

🤖 Generated with [Claude Code](https://claude.com/claude-code)