### PR TITLE
fix: remove unused role field and unify WebSocket auth with REST pipeline

### DIFF
--- a/webserver/debug_websocket.py
+++ b/webserver/debug_websocket.py
@@ -7,9 +7,8 @@ and returns responses through the WebSocket connection.
 """
 
 from flask import request
-from flask_jwt_extended import decode_token
+from flask_jwt_extended import verify_jwt_in_request
 from flask_socketio import SocketIO, emit
-from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
 
 from webserver.logger import get_logger
 
@@ -78,18 +77,18 @@ def init_debug_websocket(app, unix_client_instance):
                 logger.warning("Debug WebSocket connection attempt without token")
                 return False
 
-            try:
-                decoded = decode_token(token)
-                logger.info("Debug WebSocket connected for user %s", decoded.get("sub"))
-                emit("connected", {"status": "ok"})
-                return True
+            # Inject token into the request so verify_jwt_in_request() uses
+            # the same authentication pipeline as @jwt_required() -- including
+            # blacklist checks and user identity validation.
+            request.environ["HTTP_AUTHORIZATION"] = f"Bearer {token}"
+            verify_jwt_in_request()
 
-            except (ExpiredSignatureError, InvalidTokenError) as e:
-                logger.warning("Debug WebSocket auth failed: %s", e)
-                return False
+            logger.info("Debug WebSocket connected")
+            emit("connected", {"status": "ok"})
+            return True
 
         except Exception as e:
-            logger.error("Error during debug WebSocket connection: %s", e)
+            logger.warning("Debug WebSocket auth failed: %s", e)
             return False
 
     @_socketio.on("disconnect", namespace="/api/debug")
@@ -143,9 +142,7 @@ def init_debug_websocket(app, unix_client_instance):
                 emit("debug_response", {"success": True, "data": response_hex})
             elif response.startswith("DEBUG:ERROR"):
                 error_msg = (
-                    response.split(":", 2)[2]
-                    if len(response.split(":")) > 2
-                    else "Unknown error"
+                    response.split(":", 2)[2] if len(response.split(":")) > 2 else "Unknown error"
                 )
                 logger.warning("Debug error from runtime: %s", error_msg)
                 emit("debug_response", {"success": False, "error": error_msg})

--- a/webserver/restapi.py
+++ b/webserver/restapi.py
@@ -62,7 +62,6 @@ class User(db.Model):  # type: ignore[name-defined]
     id: int = db.Column(db.Integer, primary_key=True)
     username: str = db.Column(db.Text, nullable=False, unique=True)
     password_hash: str = db.Column(db.Text, nullable=False)
-    role: str = db.Column(db.String(20), default="user")
 
     # Use PBKDF2 with SHA256 and 600,000 iterations for password hashing
     derivation_method: str = "pbkdf2:sha256:600000"
@@ -77,7 +76,7 @@ class User(db.Model):  # type: ignore[name-defined]
         return check_password_hash(self.password_hash, password)
 
     def to_dict(self):
-        return {"id": self.id, "username": self.username, "role": self.role}
+        return {"id": self.id, "username": self.username}
 
 
 @jwt.user_identity_loader
@@ -126,10 +125,6 @@ def create_user():
             password:
               type: string
               example: openplc
-            role:
-              type: string
-              enum: [admin, user]
-              default: user
     responses:
       201:
         description: User created successfully
@@ -163,7 +158,6 @@ def create_user():
     data = request.get_json()
     username = data.get("username")
     password = data.get("password")
-    role = data.get("role", "user")
 
     if not username or not password:
         return jsonify({"msg": "Missing username or password"}), 400
@@ -172,7 +166,7 @@ def create_user():
         return jsonify({"msg": "Username already exists"}), 409
 
     # Create a new user
-    user = User(username=username, role=role)
+    user = User(username=username)
     user.set_password(password)
     db.session.add(user)
     db.session.commit()
@@ -207,9 +201,6 @@ def get_user_info(user_id):
               type: integer
               example: 1
             username:
-              type: string
-              example: admin
-            role:
               type: string
               example: admin
       404:
@@ -249,8 +240,6 @@ def get_users_info():
               id:
                 type: integer
               username:
-                type: string
-              role:
                 type: string
       404:
         description: No users found


### PR DESCRIPTION
## Summary
- Removed the vestigial `role` field from the User model, `create-user` endpoint, and all Swagger docs. OpenPLC Runtime v4 is a single-user system with no RBAC -- the field was never checked and created a false sense of role-based security.
- Fixed the debug WebSocket to use `verify_jwt_in_request()` instead of `decode_token()`, so it goes through the exact same authentication pipeline as `@jwt_required()` on all REST endpoints -- including token blacklist checks and user identity validation.

## Test plan
- [ ] Verify user creation works without the `role` field (POST `/api/create-user` with just username/password)
- [ ] Verify `GET /api/get-user-info/<id>` and `GET /api/get-users-info` responses no longer include `role`
- [ ] Verify debug WebSocket rejects revoked (logged-out) tokens
- [ ] Verify debug WebSocket rejects tokens from deleted users
- [ ] Verify debug WebSocket still accepts valid tokens normally