### PR TITLE
perf(ethercat): reduce cyclic exchange jitter via RT tuning

### DIFF
--- a/core/src/drivers/plugins/native/ethercat/CMakeLists.txt
+++ b/core/src/drivers/plugins/native/ethercat/CMakeLists.txt
@@ -137,6 +137,7 @@ set(PLUGIN_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/ethercat_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/ethercat_master.c
     ${CMAKE_CURRENT_SOURCE_DIR}/ethercat_io.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/ethercat_proc.c
     ${OPENPLC_ROOT}/core/src/drivers/plugins/native/plugin_logger.c
 )
 

--- a/core/src/drivers/plugins/native/ethercat/ethercat_config.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_config.c
@@ -15,6 +15,26 @@
 #include <stdlib.h>
 #include <string.h>
 
+/** Linux IFNAMSIZ is 16; valid iface names are 1..15 chars. */
+#define ECAT_LINUX_IFNAME_MAX 16
+
+bool ecat_is_valid_iface_name(const char *iface)
+{
+    if (iface == NULL)
+        return false;
+    size_t len = strlen(iface);
+    if (len == 0 || len >= ECAT_LINUX_IFNAME_MAX)
+        return false;
+    if (!isalpha((unsigned char)iface[0]))
+        return false;
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)iface[i];
+        if (!isalnum(c) && c != '_' && c != '-')
+            return false;
+    }
+    return true;
+}
+
 /*
  * =============================================================================
  * Helper Functions

--- a/core/src/drivers/plugins/native/ethercat/ethercat_config.h
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_config.h
@@ -276,6 +276,17 @@ int ecat_config_parse(const char *config_path, ecat_config_t *config);
 int ecat_config_validate(const ecat_config_t *config);
 
 /**
+ * @brief Check whether an interface name is a safe Linux iface identifier.
+ *
+ * Accepts only alphanumeric characters plus '_' and '-', must start with an
+ * alpha, length 1..IFNAMSIZ-1 (15). Used as a precondition before passing
+ * the name to external binaries (ethtool, iptables) or kernel /proc paths.
+ *
+ * @return true if safe, false otherwise.
+ */
+bool ecat_is_valid_iface_name(const char *iface);
+
+/**
  * @brief Initialize configuration with default values
  *
  * @param config Configuration structure to initialize

--- a/core/src/drivers/plugins/native/ethercat/ethercat_config.h
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_config.h
@@ -552,12 +552,9 @@ typedef struct {
     _Atomic(uint64_t) exchange_skips;
 #endif
 
-    /* Network interface isolation state (set by start_single_master,
-     * cleared by stop_single_master). Tracks whether we toggled each
-     * setting so we only revert what we actually applied -- avoids
-     * clobbering user configuration that was already in place. */
-    bool iface_iptables_added;     /* we inserted an INPUT DROP rule */
-    bool iface_ipv6_disabled_by_us;/* we flipped disable_ipv6 from 0->1 */
+    /* Iface isolation: true means we applied this setting and must revert. */
+    bool iface_iptables_added;
+    bool iface_ipv6_disabled_by_us;
 } ecat_master_instance_t;
 
 /**

--- a/core/src/drivers/plugins/native/ethercat/ethercat_config.h
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_config.h
@@ -551,6 +551,13 @@ typedef struct {
     _Atomic(bool) soem_paused;
     _Atomic(uint64_t) exchange_skips;
 #endif
+
+    /* Network interface isolation state (set by start_single_master,
+     * cleared by stop_single_master). Tracks whether we toggled each
+     * setting so we only revert what we actually applied -- avoids
+     * clobbering user configuration that was already in place. */
+    bool iface_iptables_added;     /* we inserted an INPUT DROP rule */
+    bool iface_ipv6_disabled_by_us;/* we flipped disable_ipv6 from 0->1 */
 } ecat_master_instance_t;
 
 /**

--- a/core/src/drivers/plugins/native/ethercat/ethercat_master.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_master.c
@@ -11,6 +11,7 @@
  */
 
 #include "ethercat_master.h"
+#include "ethercat_proc.h"
 #include "soem/soem.h"
 
 #include <ctype.h>
@@ -180,50 +181,6 @@ static int parse_ethtool_bool(const char *output, const char *key, int *value)
     return 0;
 }
 
-/**
- * @brief Run a command and capture its stdout into a buffer.
- *
- * @return 0 on success, -1 on failure
- */
-static int run_capture(const char *cmd, char *buf, size_t buf_size)
-{
-    FILE *fp = popen(cmd, "r");
-    if (!fp)
-        return -1;
-    size_t total = 0;
-    while (total < buf_size - 1) {
-        size_t n = fread(buf + total, 1, buf_size - 1 - total, fp);
-        if (n == 0)
-            break;
-        total += n;
-    }
-    buf[total] = '\0';
-    int status = pclose(fp);
-    return (status == 0) ? 0 : -1;
-}
-
-/**
- * @brief Validate interface name contains only safe characters (alnum, _ , -).
- *
- * Prevents command injection when the name is interpolated into shell commands.
- *
- * @return 1 if safe, 0 if invalid
- */
-static int validate_iface_name(const char *iface)
-{
-    size_t len = strlen(iface);
-    if (len == 0 || len >= NIC_IFNAME_MAX)
-        return 0;
-    if (!isalpha((unsigned char)iface[0]))
-        return 0;
-    for (size_t i = 0; i < len; i++) {
-        unsigned char c = (unsigned char)iface[i];
-        if (!isalnum(c) && c != '_' && c != '-')
-            return 0;
-    }
-    return 1;
-}
-
 /* ------------------------------------------------------------------ */
 /*  Persistence: write / read / remove the save file                   */
 /* ------------------------------------------------------------------ */
@@ -369,7 +326,7 @@ static nic_saved_settings_t *load_nic_settings_from_file(const char *iface, plug
 
     fclose(fp);
 
-    if (tmp.iface[0] == '\0' || !validate_iface_name(tmp.iface)) {
+    if (tmp.iface[0] == '\0' || !ecat_is_valid_iface_name(tmp.iface)) {
         plugin_logger_warn(logger,
             "Invalid or empty interface in %s - discarding", save_file);
         remove_nic_save_file(iface, logger);
@@ -418,38 +375,41 @@ static void save_nic_settings(const char *iface, plugin_logger_t *logger)
     strncpy(local.iface, iface, NIC_IFNAME_MAX - 1);
     local.iface[NIC_IFNAME_MAX - 1] = '\0';
 
-    char cmd[128];
     char output[2048];
 
     /* Capture coalescing settings */
-    snprintf(cmd, sizeof(cmd), "ethtool -c %s 2>/dev/null", iface);
-    if (run_capture(cmd, output, sizeof(output)) == 0) {
-        int ok = 0;
-        ok += (parse_ethtool_int(output, "rx-usecs", &local.rx_usecs) == 0);
-        ok += (parse_ethtool_int(output, "tx-usecs", &local.tx_usecs) == 0);
-        if (ok > 0) {
-            local.coalescing_saved = 1;
-            plugin_logger_info(logger,
-                "%s: saved coalescing (rx-usecs=%d, tx-usecs=%d)",
-                iface, local.rx_usecs, local.tx_usecs);
+    {
+        char *argv[] = { "ethtool", "-c", (char *)iface, NULL };
+        if (ecat_run_argv("ethtool", argv, output, sizeof(output)) == 0) {
+            int ok = 0;
+            ok += (parse_ethtool_int(output, "rx-usecs", &local.rx_usecs) == 0);
+            ok += (parse_ethtool_int(output, "tx-usecs", &local.tx_usecs) == 0);
+            if (ok > 0) {
+                local.coalescing_saved = 1;
+                plugin_logger_info(logger,
+                    "%s: saved coalescing (rx-usecs=%d, tx-usecs=%d)",
+                    iface, local.rx_usecs, local.tx_usecs);
+            }
         }
     }
 
     /* Capture offload settings */
-    snprintf(cmd, sizeof(cmd), "ethtool -k %s 2>/dev/null", iface);
-    if (run_capture(cmd, output, sizeof(output)) == 0) {
-        int ok = 0;
-        ok += (parse_ethtool_bool(output, "generic-receive-offload", &local.gro) == 0);
-        ok += (parse_ethtool_bool(output, "generic-segmentation-offload", &local.gso) == 0);
-        ok += (parse_ethtool_bool(output, "tcp-segmentation-offload", &local.tso) == 0);
-        if (ok > 0) {
-            local.offloads_saved = 1;
-            plugin_logger_info(logger,
-                "%s: saved offloads (gro=%s, gso=%s, tso=%s)",
-                iface,
-                local.gro ? "on" : "off",
-                local.gso ? "on" : "off",
-                local.tso ? "on" : "off");
+    {
+        char *argv[] = { "ethtool", "-k", (char *)iface, NULL };
+        if (ecat_run_argv("ethtool", argv, output, sizeof(output)) == 0) {
+            int ok = 0;
+            ok += (parse_ethtool_bool(output, "generic-receive-offload", &local.gro) == 0);
+            ok += (parse_ethtool_bool(output, "generic-segmentation-offload", &local.gso) == 0);
+            ok += (parse_ethtool_bool(output, "tcp-segmentation-offload", &local.tso) == 0);
+            if (ok > 0) {
+                local.offloads_saved = 1;
+                plugin_logger_info(logger,
+                    "%s: saved offloads (gro=%s, gso=%s, tso=%s)",
+                    iface,
+                    local.gro ? "on" : "off",
+                    local.gso ? "on" : "off",
+                    local.tso ? "on" : "off");
+            }
         }
     }
 
@@ -486,14 +446,18 @@ static void restore_nic_settings(const char *iface, plugin_logger_t *logger)
     ns->saved = 0;
     pthread_mutex_unlock(&g_nic_saved_mutex);
 
-    /* Restore NIC settings (slow shell calls -- run without lock) */
-    char cmd[128];
-
+    /* Restore NIC settings (slow exec calls -- run without lock) */
     if (local.coalescing_saved) {
-        snprintf(cmd, sizeof(cmd),
-            "ethtool -C %s rx-usecs %d tx-usecs %d 2>/dev/null",
-            iface, local.rx_usecs, local.tx_usecs);
-        if (system(cmd) == 0) {
+        char rx_str[16], tx_str[16];
+        snprintf(rx_str, sizeof(rx_str), "%d", local.rx_usecs);
+        snprintf(tx_str, sizeof(tx_str), "%d", local.tx_usecs);
+        char *argv[] = {
+            "ethtool", "-C", (char *)iface,
+            "rx-usecs", rx_str,
+            "tx-usecs", tx_str,
+            NULL
+        };
+        if (ecat_run_argv("ethtool", argv, NULL, 0) == 0) {
             plugin_logger_info(logger,
                 "%s: restored coalescing (rx-usecs=%d, tx-usecs=%d)",
                 iface, local.rx_usecs, local.tx_usecs);
@@ -501,13 +465,14 @@ static void restore_nic_settings(const char *iface, plugin_logger_t *logger)
     }
 
     if (local.offloads_saved) {
-        snprintf(cmd, sizeof(cmd),
-            "ethtool -K %s gro %s gso %s tso %s 2>/dev/null",
-            iface,
-            local.gro ? "on" : "off",
-            local.gso ? "on" : "off",
-            local.tso ? "on" : "off");
-        if (system(cmd) == 0) {
+        char *argv[] = {
+            "ethtool", "-K", (char *)iface,
+            "gro", local.gro ? "on" : "off",
+            "gso", local.gso ? "on" : "off",
+            "tso", local.tso ? "on" : "off",
+            NULL
+        };
+        if (ecat_run_argv("ethtool", argv, NULL, 0) == 0) {
             plugin_logger_info(logger,
                 "%s: restored offloads (gro=%s, gso=%s, tso=%s)",
                 iface,
@@ -649,9 +614,7 @@ int ecat_master_validate_topology(ecat_master_instance_t *inst, plugin_logger_t 
 static void tune_nic(const char *iface, plugin_logger_t *logger)
 {
 #if !defined(__CYGWIN__) && !defined(_WIN32)
-    char cmd[128];
-
-    if (!validate_iface_name(iface)) {
+    if (!ecat_is_valid_iface_name(iface)) {
         plugin_logger_warn(logger, "Skipping NIC tuning: invalid interface name '%s'", iface);
         return;
     }
@@ -663,17 +626,31 @@ static void tune_nic(const char *iface, plugin_logger_t *logger)
     save_nic_settings(iface, logger);
 
     /* Disable IRQ coalescing - deliver frames immediately */
-    snprintf(cmd, sizeof(cmd), "ethtool -C %s rx-usecs 0 tx-usecs 0 2>/dev/null", iface);
-    if (system(cmd) == 0)
     {
-        plugin_logger_info(logger, "%s: IRQ coalescing disabled (rx-usecs=0 tx-usecs=0)", iface);
+        char *argv[] = {
+            "ethtool", "-C", (char *)iface,
+            "rx-usecs", "0",
+            "tx-usecs", "0",
+            NULL
+        };
+        if (ecat_run_argv("ethtool", argv, NULL, 0) == 0) {
+            plugin_logger_info(logger,
+                "%s: IRQ coalescing disabled (rx-usecs=0 tx-usecs=0)", iface);
+        }
     }
 
     /* Disable receive offloads that batch/merge packets */
-    snprintf(cmd, sizeof(cmd), "ethtool -K %s gro off gso off tso off 2>/dev/null", iface);
-    if (system(cmd) == 0)
     {
-        plugin_logger_info(logger, "%s: GRO/GSO/TSO offloads disabled", iface);
+        char *argv[] = {
+            "ethtool", "-K", (char *)iface,
+            "gro", "off",
+            "gso", "off",
+            "tso", "off",
+            NULL
+        };
+        if (ecat_run_argv("ethtool", argv, NULL, 0) == 0) {
+            plugin_logger_info(logger, "%s: GRO/GSO/TSO offloads disabled", iface);
+        }
     }
 #else
     (void)iface;

--- a/core/src/drivers/plugins/native/ethercat/ethercat_plugin.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_plugin.c
@@ -24,7 +24,7 @@
  */
 
 #include <ctype.h>
-#include <stdarg.h>
+#include <errno.h>
 #include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -32,8 +32,9 @@
 #include <string.h>
 #include <stdbool.h>
 #include <pthread.h>
-#include <sys/wait.h>
+#include <sys/stat.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "plugin_logger.h"
 #include "plugin_types.h"
@@ -41,6 +42,7 @@
 #include "ethercat_config.h"
 #include "ethercat_master.h"
 #include "ethercat_io.h"
+#include "ethercat_proc.h"
 #include "soem/soem.h"   /* osal_get_monotonic_time, ec_timet */
 #include "cjson/cJSON.h"  /* JSON parsing for execute_command */
 
@@ -139,27 +141,13 @@ static void safe_strcpy_local(char *dest, const char *src, size_t max_len)
  * =============================================================================
  *
  * Silences IP traffic on the EtherCAT NIC for the duration of the master.
- * State flags ensure we revert only what we applied.
+ * State flags ensure we revert only what we applied. State is also
+ * persisted to /run/runtime/ so a crashed runtime does not leak iptables
+ * rules or IPv6 sysctl flips into the next boot's environment.
  */
 
-/**
- * @brief Run a shell command via system(); returns process exit code or -1
- */
-static int run_shell_cmd(const char *fmt, ...)
-{
-    char cmd[256];
-    va_list ap;
-    va_start(ap, fmt);
-    int n = vsnprintf(cmd, sizeof(cmd), fmt, ap);
-    va_end(ap);
-    if (n < 0 || (size_t)n >= sizeof(cmd))
-        return -1;
-
-    int rc = system(cmd);
-    if (rc == -1)
-        return -1;
-    return WIFEXITED(rc) ? WEXITSTATUS(rc) : -1;
-}
+#define ECAT_ISO_STATE_DIR  "/run/runtime"
+#define ECAT_ISO_STATE_FMT  "/run/runtime/ecat_iface_iso_%s.state"
 
 /**
  * @brief Read /proc/sys/net/ipv6/conf/<iface>/disable_ipv6 ; returns 0/1 or -1
@@ -193,6 +181,153 @@ static int write_ipv6_disabled(const char *iface, int value)
 }
 
 /**
+ * @brief Run `iptables -D INPUT -i <iface> -j DROP`
+ */
+static int iptables_delete(const char *iface)
+{
+    char *argv[] = {
+        "iptables", "-D", "INPUT", "-i", (char *)iface, "-j", "DROP", NULL
+    };
+    return ecat_run_argv("iptables", argv, NULL, 0);
+}
+
+/**
+ * @brief Run `iptables -I INPUT 1 -i <iface> -j DROP`
+ */
+static int iptables_insert(const char *iface)
+{
+    char *argv[] = {
+        "iptables", "-I", "INPUT", "1", "-i", (char *)iface, "-j", "DROP", NULL
+    };
+    return ecat_run_argv("iptables", argv, NULL, 0);
+}
+
+/**
+ * @brief Build the per-iface persistence file path.
+ */
+static void iso_state_path(const char *iface, char *buf, size_t size)
+{
+    snprintf(buf, size, ECAT_ISO_STATE_FMT, iface);
+}
+
+/**
+ * @brief Persist the in-memory isolation state for an interface to disk.
+ *
+ * Atomic write via temp + rename, mirroring the NIC-settings persistence.
+ * On a crash, the state file lets the next start undo what we applied.
+ */
+static void persist_iso_state(const char *iface,
+                              bool iptables_added, bool ipv6_disabled,
+                              plugin_logger_t *logger)
+{
+    if (mkdir(ECAT_ISO_STATE_DIR, 0755) != 0 && errno != EEXIST) {
+        plugin_logger_warn(logger,
+            "Cannot create %s: %s - iface isolation will not survive a crash",
+            ECAT_ISO_STATE_DIR, strerror(errno));
+        return;
+    }
+
+    char path[160];
+    iso_state_path(iface, path, sizeof(path));
+
+    char tmp[176];
+    snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+
+    FILE *fp = fopen(tmp, "w");
+    if (!fp) {
+        plugin_logger_warn(logger,
+            "Cannot write %s: %s - iface isolation will not survive a crash",
+            tmp, strerror(errno));
+        return;
+    }
+    fprintf(fp, "iface=%s\n", iface);
+    fprintf(fp, "iptables_added=%d\n", iptables_added ? 1 : 0);
+    fprintf(fp, "ipv6_disabled_by_us=%d\n", ipv6_disabled ? 1 : 0);
+    fflush(fp);
+    fclose(fp);
+
+    if (rename(tmp, path) != 0) {
+        plugin_logger_warn(logger, "Cannot rename %s -> %s: %s",
+                           tmp, path, strerror(errno));
+        unlink(tmp);
+    }
+}
+
+/**
+ * @brief Remove the persistence file (no-op if it doesn't exist).
+ */
+static void remove_iso_state(const char *iface)
+{
+    char path[160];
+    iso_state_path(iface, path, sizeof(path));
+    unlink(path);
+}
+
+/**
+ * @brief Load persisted isolation state for an interface, if present.
+ *
+ * @return true if a valid state file was found and parsed.
+ */
+static bool load_iso_state(const char *iface,
+                           bool *iptables_added, bool *ipv6_disabled)
+{
+    char path[160];
+    iso_state_path(iface, path, sizeof(path));
+    FILE *fp = fopen(path, "r");
+    if (!fp)
+        return false;
+
+    *iptables_added = false;
+    *ipv6_disabled = false;
+
+    char line[128];
+    while (fgets(line, sizeof(line), fp)) {
+        size_t len = strlen(line);
+        if (len > 0 && line[len - 1] == '\n')
+            line[len - 1] = '\0';
+        char *eq = strchr(line, '=');
+        if (!eq)
+            continue;
+        *eq = '\0';
+        const char *key = line;
+        const char *val = eq + 1;
+        if (strcmp(key, "iptables_added") == 0) {
+            *iptables_added = (atoi(val) != 0);
+        } else if (strcmp(key, "ipv6_disabled_by_us") == 0) {
+            *ipv6_disabled = (atoi(val) != 0);
+        }
+    }
+    fclose(fp);
+    return true;
+}
+
+/**
+ * @brief Recover isolation state left over from a previous crashed run.
+ *
+ * Mirrors recover_nic_settings() in ethercat_master.c. Called from
+ * apply_iface_isolation before applying fresh state.
+ */
+static void recover_iso_state(const char *iface, plugin_logger_t *logger)
+{
+    bool ipt = false, ipv6 = false;
+    if (!load_iso_state(iface, &ipt, &ipv6))
+        return;
+
+    plugin_logger_warn(logger,
+        "Found stale iface-isolation state for %s "
+        "(iptables=%d ipv6=%d) - previous process likely crashed. "
+        "Reverting before re-applying.",
+        iface, (int)ipt, (int)ipv6);
+
+    if (ipt)
+        iptables_delete(iface);
+    if (ipv6)
+        write_ipv6_disabled(iface, 0);
+
+    remove_iso_state(iface);
+}
+
+/**
  * @brief Apply IP-stack isolation to the master's interface
  */
 static void apply_iface_isolation(ecat_master_instance_t *inst,
@@ -205,11 +340,23 @@ static void apply_iface_isolation(ecat_master_instance_t *inst,
     inst->iface_iptables_added = false;
     inst->iface_ipv6_disabled_by_us = false;
 
+    if (!ecat_is_valid_iface_name(iface)) {
+        plugin_logger_warn(logger,
+            "Master '%s': interface '%s' is not a valid Linux iface name - "
+            "skipping IP-stack isolation", inst->name, iface);
+        return;
+    }
+
+    /* If a previous process crashed, undo whatever it left behind first. */
+    recover_iso_state(iface, logger);
+
     /* Only flip IPv6 if it was on, so we never undo an operator setting. */
     int ipv6 = read_ipv6_disabled(iface);
     if (ipv6 == 0) {
         if (write_ipv6_disabled(iface, 1) == 0) {
             inst->iface_ipv6_disabled_by_us = true;
+            persist_iso_state(iface, inst->iface_iptables_added,
+                              inst->iface_ipv6_disabled_by_us, logger);
             plugin_logger_info(logger,
                 "Master '%s': disabled IPv6 on %s (jitter isolation)",
                 inst->name, iface);
@@ -224,10 +371,12 @@ static void apply_iface_isolation(ecat_master_instance_t *inst,
     }
 
     /* Delete-then-insert keeps the rule unique across re-runs. */
-    run_shell_cmd("iptables -D INPUT -i %s -j DROP 2>/dev/null", iface);
-    int rc = run_shell_cmd("iptables -I INPUT 1 -i %s -j DROP 2>/dev/null", iface);
+    iptables_delete(iface);
+    int rc = iptables_insert(iface);
     if (rc == 0) {
         inst->iface_iptables_added = true;
+        persist_iso_state(iface, inst->iface_iptables_added,
+                          inst->iface_ipv6_disabled_by_us, logger);
         plugin_logger_info(logger,
             "Master '%s': inserted iptables INPUT DROP for %s "
             "(jitter isolation)", inst->name, iface);
@@ -236,6 +385,10 @@ static void apply_iface_isolation(ecat_master_instance_t *inst,
             "Master '%s': iptables -I INPUT failed for %s (rc=%d) -- "
             "isolation skipped", inst->name, iface, rc);
     }
+
+    /* If we ended up doing nothing, do not leave a stale state file. */
+    if (!inst->iface_iptables_added && !inst->iface_ipv6_disabled_by_us)
+        remove_iso_state(iface);
 }
 
 /**
@@ -249,7 +402,7 @@ static void revert_iface_isolation(ecat_master_instance_t *inst,
         return;
 
     if (inst->iface_iptables_added) {
-        run_shell_cmd("iptables -D INPUT -i %s -j DROP 2>/dev/null", iface);
+        iptables_delete(iface);
         plugin_logger_info(logger,
             "Master '%s': removed iptables INPUT DROP for %s",
             inst->name, iface);
@@ -261,6 +414,9 @@ static void revert_iface_isolation(ecat_master_instance_t *inst,
             "Master '%s': re-enabled IPv6 on %s", inst->name, iface);
         inst->iface_ipv6_disabled_by_us = false;
     }
+
+    /* Drop the persistence file so the next start does not see stale state. */
+    remove_iso_state(iface);
 }
 
 /*

--- a/core/src/drivers/plugins/native/ethercat/ethercat_plugin.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_plugin.c
@@ -138,19 +138,8 @@ static void safe_strcpy_local(char *dest, const char *src, size_t max_len)
  * Network Interface Isolation (per-master, lifecycle-bound)
  * =============================================================================
  *
- * SOEM uses AF_PACKET with an EtherType filter for 0x88A4, so the userspace
- * only sees EtherCAT frames. But the kernel still processes ARP, IPv6-NS,
- * multicast, broadcast, etc. on any interface that has IP enabled, costing
- * a few microseconds of softirq work per stray packet -- contributing to
- * worst-case jitter on the cyclic exchange.
- *
- * On start_loop we silence the IP stack on the EtherCAT NIC by:
- *   1. Setting disable_ipv6 (only if it was previously enabled).
- *   2. Inserting an iptables INPUT DROP rule for the interface.
- * Both are tracked per-master and reverted in stop_loop only if we applied
- * them, so we never clobber configuration the operator already had.
- *
- * Requires root, which the plugin already has (raw AF_PACKET socket).
+ * Silences IP traffic on the EtherCAT NIC for the duration of the master.
+ * State flags ensure we revert only what we applied.
  */
 
 /**
@@ -216,7 +205,7 @@ static void apply_iface_isolation(ecat_master_instance_t *inst,
     inst->iface_iptables_added = false;
     inst->iface_ipv6_disabled_by_us = false;
 
-    /* IPv6: only flip if currently enabled (don't undo a user setting). */
+    /* Only flip IPv6 if it was on, so we never undo an operator setting. */
     int ipv6 = read_ipv6_disabled(iface);
     if (ipv6 == 0) {
         if (write_ipv6_disabled(iface, 1) == 0) {
@@ -234,8 +223,7 @@ static void apply_iface_isolation(ecat_master_instance_t *inst,
             "Master '%s': IPv6 already disabled on %s", inst->name, iface);
     }
 
-    /* iptables: delete any stale rule first (idempotent), then insert at top
-     * so we win against any pre-existing ACCEPT rules above. */
+    /* Delete-then-insert keeps the rule unique across re-runs. */
     run_shell_cmd("iptables -D INPUT -i %s -j DROP 2>/dev/null", iface);
     int rc = run_shell_cmd("iptables -I INPUT 1 -i %s -j DROP 2>/dev/null", iface);
     if (rc == 0) {

--- a/core/src/drivers/plugins/native/ethercat/ethercat_plugin.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_plugin.c
@@ -24,6 +24,7 @@
  */
 
 #include <ctype.h>
+#include <stdarg.h>
 #include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -31,6 +32,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <pthread.h>
+#include <sys/wait.h>
 #include <time.h>
 
 #include "plugin_logger.h"
@@ -129,6 +131,148 @@ static void safe_strcpy_local(char *dest, const char *src, size_t max_len)
     if (src == NULL) { dest[0] = '\0'; return; }
     strncpy(dest, src, max_len - 1);
     dest[max_len - 1] = '\0';
+}
+
+/*
+ * =============================================================================
+ * Network Interface Isolation (per-master, lifecycle-bound)
+ * =============================================================================
+ *
+ * SOEM uses AF_PACKET with an EtherType filter for 0x88A4, so the userspace
+ * only sees EtherCAT frames. But the kernel still processes ARP, IPv6-NS,
+ * multicast, broadcast, etc. on any interface that has IP enabled, costing
+ * a few microseconds of softirq work per stray packet -- contributing to
+ * worst-case jitter on the cyclic exchange.
+ *
+ * On start_loop we silence the IP stack on the EtherCAT NIC by:
+ *   1. Setting disable_ipv6 (only if it was previously enabled).
+ *   2. Inserting an iptables INPUT DROP rule for the interface.
+ * Both are tracked per-master and reverted in stop_loop only if we applied
+ * them, so we never clobber configuration the operator already had.
+ *
+ * Requires root, which the plugin already has (raw AF_PACKET socket).
+ */
+
+/**
+ * @brief Run a shell command via system(); returns process exit code or -1
+ */
+static int run_shell_cmd(const char *fmt, ...)
+{
+    char cmd[256];
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(cmd, sizeof(cmd), fmt, ap);
+    va_end(ap);
+    if (n < 0 || (size_t)n >= sizeof(cmd))
+        return -1;
+
+    int rc = system(cmd);
+    if (rc == -1)
+        return -1;
+    return WIFEXITED(rc) ? WEXITSTATUS(rc) : -1;
+}
+
+/**
+ * @brief Read /proc/sys/net/ipv6/conf/<iface>/disable_ipv6 ; returns 0/1 or -1
+ */
+static int read_ipv6_disabled(const char *iface)
+{
+    char path[160];
+    snprintf(path, sizeof(path),
+             "/proc/sys/net/ipv6/conf/%s/disable_ipv6", iface);
+    FILE *f = fopen(path, "r");
+    if (!f) return -1;
+    int v = -1;
+    if (fscanf(f, "%d", &v) != 1) v = -1;
+    fclose(f);
+    return v;
+}
+
+/**
+ * @brief Write disable_ipv6 sysctl for the given interface
+ */
+static int write_ipv6_disabled(const char *iface, int value)
+{
+    char path[160];
+    snprintf(path, sizeof(path),
+             "/proc/sys/net/ipv6/conf/%s/disable_ipv6", iface);
+    FILE *f = fopen(path, "w");
+    if (!f) return -1;
+    int rc = (fprintf(f, "%d\n", value) > 0) ? 0 : -1;
+    fclose(f);
+    return rc;
+}
+
+/**
+ * @brief Apply IP-stack isolation to the master's interface
+ */
+static void apply_iface_isolation(ecat_master_instance_t *inst,
+                                  plugin_logger_t *logger)
+{
+    const char *iface = inst->config.master.interface;
+    if (iface[0] == '\0')
+        return;
+
+    inst->iface_iptables_added = false;
+    inst->iface_ipv6_disabled_by_us = false;
+
+    /* IPv6: only flip if currently enabled (don't undo a user setting). */
+    int ipv6 = read_ipv6_disabled(iface);
+    if (ipv6 == 0) {
+        if (write_ipv6_disabled(iface, 1) == 0) {
+            inst->iface_ipv6_disabled_by_us = true;
+            plugin_logger_info(logger,
+                "Master '%s': disabled IPv6 on %s (jitter isolation)",
+                inst->name, iface);
+        } else {
+            plugin_logger_warn(logger,
+                "Master '%s': could not disable IPv6 on %s",
+                inst->name, iface);
+        }
+    } else if (ipv6 == 1) {
+        plugin_logger_debug(logger,
+            "Master '%s': IPv6 already disabled on %s", inst->name, iface);
+    }
+
+    /* iptables: delete any stale rule first (idempotent), then insert at top
+     * so we win against any pre-existing ACCEPT rules above. */
+    run_shell_cmd("iptables -D INPUT -i %s -j DROP 2>/dev/null", iface);
+    int rc = run_shell_cmd("iptables -I INPUT 1 -i %s -j DROP 2>/dev/null", iface);
+    if (rc == 0) {
+        inst->iface_iptables_added = true;
+        plugin_logger_info(logger,
+            "Master '%s': inserted iptables INPUT DROP for %s "
+            "(jitter isolation)", inst->name, iface);
+    } else {
+        plugin_logger_warn(logger,
+            "Master '%s': iptables -I INPUT failed for %s (rc=%d) -- "
+            "isolation skipped", inst->name, iface, rc);
+    }
+}
+
+/**
+ * @brief Revert IP-stack isolation -- only what we applied.
+ */
+static void revert_iface_isolation(ecat_master_instance_t *inst,
+                                   plugin_logger_t *logger)
+{
+    const char *iface = inst->config.master.interface;
+    if (iface[0] == '\0')
+        return;
+
+    if (inst->iface_iptables_added) {
+        run_shell_cmd("iptables -D INPUT -i %s -j DROP 2>/dev/null", iface);
+        plugin_logger_info(logger,
+            "Master '%s': removed iptables INPUT DROP for %s",
+            inst->name, iface);
+        inst->iface_iptables_added = false;
+    }
+    if (inst->iface_ipv6_disabled_by_us) {
+        write_ipv6_disabled(iface, 0);
+        plugin_logger_info(logger,
+            "Master '%s': re-enabled IPv6 on %s", inst->name, iface);
+        inst->iface_ipv6_disabled_by_us = false;
+    }
 }
 
 /*
@@ -513,6 +657,9 @@ static int start_single_master(ecat_master_instance_t *inst)
     }
 #endif
 
+    /* Silence the IP stack on the EtherCAT NIC. Reverted in stop_single_master. */
+    apply_iface_isolation(inst, &g_logger);
+
     plugin_logger_info(&g_logger,
         "Master '%s': [state: OPERATIONAL] EtherCAT master started "
         "(synchronous exchange, monitor=%s)",
@@ -567,6 +714,9 @@ static void stop_single_master(ecat_master_instance_t *inst)
             (unsigned long long)(inst->diag.min_total_ns / 1000),
             (unsigned long long)(inst->diag.max_total_ns / 1000));
     }
+
+    /* Undo IP-stack isolation only if we applied it -- safe to call always. */
+    revert_iface_isolation(inst, &g_logger);
 
     memset(&inst->channel_map, 0, sizeof(inst->channel_map));
     memset(&inst->transfer_list, 0, sizeof(inst->transfer_list));

--- a/core/src/drivers/plugins/native/ethercat/ethercat_proc.c
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_proc.c
@@ -1,0 +1,93 @@
+/**
+ * @file ethercat_proc.c
+ * @brief Process-spawn helpers for the EtherCAT plugin.
+ */
+
+#include "ethercat_proc.h"
+
+#if !defined(__CYGWIN__) && !defined(_WIN32)
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+
+int ecat_run_argv(const char *bin, char *const argv[],
+                  char *capture_buf, size_t capture_size)
+{
+    if (bin == NULL || argv == NULL)
+        return -1;
+
+    int pipefd[2] = { -1, -1 };
+    int capturing = (capture_buf != NULL && capture_size > 0);
+    if (capturing) {
+        if (pipe(pipefd) != 0)
+            return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        if (capturing) { close(pipefd[0]); close(pipefd[1]); }
+        return -1;
+    }
+
+    if (pid == 0) {
+        /* --- child --- */
+        int devnull = open("/dev/null", O_WRONLY);
+        if (capturing) {
+            close(pipefd[0]);
+            if (pipefd[1] != STDOUT_FILENO) {
+                dup2(pipefd[1], STDOUT_FILENO);
+                close(pipefd[1]);
+            }
+        } else if (devnull >= 0) {
+            dup2(devnull, STDOUT_FILENO);
+        }
+        if (devnull >= 0) {
+            dup2(devnull, STDERR_FILENO);
+            if (devnull > STDERR_FILENO)
+                close(devnull);
+        }
+        execvp(bin, argv);
+        _exit(127);
+    }
+
+    /* --- parent --- */
+    if (capturing) {
+        close(pipefd[1]);
+        size_t total = 0;
+        while (total + 1 < capture_size) {
+            ssize_t n = read(pipefd[0], capture_buf + total,
+                             capture_size - 1 - total);
+            if (n <= 0)
+                break;
+            total += (size_t)n;
+        }
+        capture_buf[total] = '\0';
+        /* Drain any remaining output so the child does not block on a
+         * full pipe; we have already truncated to capture_size. */
+        char drain[256];
+        while (read(pipefd[0], drain, sizeof(drain)) > 0)
+            ;
+        close(pipefd[0]);
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0)
+        return -1;
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+}
+
+#else /* MSYS2 / Cygwin / native Windows -- shell-out paths are not used */
+
+int ecat_run_argv(const char *bin, char *const argv[],
+                  char *capture_buf, size_t capture_size)
+{
+    (void)bin;
+    (void)argv;
+    (void)capture_buf;
+    (void)capture_size;
+    return -1;
+}
+
+#endif

--- a/core/src/drivers/plugins/native/ethercat/ethercat_proc.h
+++ b/core/src/drivers/plugins/native/ethercat/ethercat_proc.h
@@ -1,0 +1,46 @@
+/**
+ * @file ethercat_proc.h
+ * @brief Process-spawn helpers for the EtherCAT plugin.
+ *
+ * Wraps fork+execvp so the plugin can invoke external binaries (ethtool,
+ * iptables) without going through a shell. Argv elements are passed
+ * verbatim to execvp, so user-controlled strings (e.g. the configured
+ * NIC interface name) cannot be reinterpreted as shell metacharacters.
+ */
+
+#ifndef ETHERCAT_PROC_H
+#define ETHERCAT_PROC_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Run an external binary with explicit argv via fork+execvp.
+ *
+ * No shell is involved. argv must be NULL-terminated; argv[0] is passed
+ * to the child as its argv[0] (conventionally equal to @p bin).
+ *
+ * Stderr in the child is always redirected to /dev/null. Stdout is either
+ * captured (if @p capture_buf is non-NULL) or also redirected to /dev/null.
+ *
+ * @param bin           Binary name (resolved via PATH by execvp).
+ * @param argv          NULL-terminated argument vector.
+ * @param capture_buf   Optional buffer to receive child stdout, NUL-terminated.
+ *                      Output is truncated to @p capture_size - 1 bytes.
+ * @param capture_size  Size of @p capture_buf. Ignored if buffer is NULL.
+ *
+ * @return Exit status of the child (0 on success, non-zero from the child
+ *         such as 127 if execvp failed), or -1 if the parent could not
+ *         spawn or wait. Always returns -1 on non-Linux platforms.
+ */
+int ecat_run_argv(const char *bin, char *const argv[],
+                  char *capture_buf, size_t capture_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ETHERCAT_PROC_H */

--- a/core/src/plc_app/plc_state_manager.c
+++ b/core/src/plc_app/plc_state_manager.c
@@ -73,9 +73,11 @@ void *plc_cycle_thread(void *arg)
         log_error("Failed to initialize scan cycle manager");
     }
 
-    // Initialize PLC with real-time optimizations
-    set_realtime_priority();
+    // Lock memory eagerly so any allocation done during plugin/program init
+    // is already pinned. mlockall is process-wide and idempotent, so it does
+    // not need to wait for the RT-priority elevation below.
     lock_memory();
+
     symbols_init(pm);
     ext_config_init__();
     ext_glueVars();
@@ -119,6 +121,16 @@ void *plc_cycle_thread(void *arg)
         plugin_driver_start(plugin_driver);
         log_info("[PLUGIN]: Enabled plugins started");
     }
+
+    // Promote THIS thread to SCHED_FIFO 20 + isolated CPU only AFTER all
+    // plugin/I/O threads have been spawned. Linux pthreads default to
+    // PTHREAD_INHERIT_SCHED, so any pthread_create() called before this
+    // point inherits the calling (still SCHED_OTHER) thread, leaving the
+    // scan as the only RT thread on the isolated CPU. Calling this earlier
+    // caused housekeeping threads (unix socket, log streamer, plugin
+    // helpers) to silently inherit FIFO 20 and queue against the cyclic
+    // exchange, costing ~120us of jitter.
+    set_realtime_priority();
 
     // Install signal handlers for crash recovery BEFORE entering the main loop.
     // This allows SIGFPE (e.g. division by zero) and SIGSEGV (e.g. bad array

--- a/core/src/plc_app/plc_state_manager.c
+++ b/core/src/plc_app/plc_state_manager.c
@@ -73,9 +73,7 @@ void *plc_cycle_thread(void *arg)
         log_error("Failed to initialize scan cycle manager");
     }
 
-    // Lock memory eagerly so any allocation done during plugin/program init
-    // is already pinned. mlockall is process-wide and idempotent, so it does
-    // not need to wait for the RT-priority elevation below.
+    // mlockall is process-wide; safe to call before plugin init.
     lock_memory();
 
     symbols_init(pm);
@@ -122,14 +120,9 @@ void *plc_cycle_thread(void *arg)
         log_info("[PLUGIN]: Enabled plugins started");
     }
 
-    // Promote THIS thread to SCHED_FIFO 20 + isolated CPU only AFTER all
-    // plugin/I/O threads have been spawned. Linux pthreads default to
-    // PTHREAD_INHERIT_SCHED, so any pthread_create() called before this
-    // point inherits the calling (still SCHED_OTHER) thread, leaving the
-    // scan as the only RT thread on the isolated CPU. Calling this earlier
-    // caused housekeeping threads (unix socket, log streamer, plugin
-    // helpers) to silently inherit FIFO 20 and queue against the cyclic
-    // exchange, costing ~120us of jitter.
+    // Elevate AFTER plugins start: pthread default is PTHREAD_INHERIT_SCHED,
+    // so any thread spawned during plugin_driver_start would otherwise
+    // inherit FIFO and contend with the scan on its core.
     set_realtime_priority();
 
     // Install signal handlers for crash recovery BEFORE entering the main loop.

--- a/core/src/plc_app/utils/utils.c
+++ b/core/src/plc_app/utils/utils.c
@@ -73,19 +73,13 @@ void timespec_diff(struct timespec *a, struct timespec *b, struct timespec *resu
     }
 }
 
-// Configure SCHED_FIFO priority and reduce timer slack on the PLC scan thread.
-//
-// CPU affinity / pinning is intentionally NOT applied here. Pinning to a
-// specific core is a deployment concern (which CPU is isolated, whether the
-// host has multiple physical packages, container cpuset restrictions, etc.)
-// and the runtime should stay hardware-agnostic. Operators control affinity
-// at deployment time via taskset, cgroup cpuset, container --cpuset-cpus, or
-// the `CPUAffinity=` directive of the systemd service unit.
+// CPU affinity is left to deployment (taskset, cgroup cpuset, systemd
+// CPUAffinity=) so the runtime stays hardware-agnostic.
 void set_realtime_priority(void)
 {
 #if HAS_REALTIME_FEATURES
     struct sched_param param;
-    param.sched_priority = 20; // Priority between 1 and 99
+    param.sched_priority = 20;
 
     if (sched_setscheduler(0, SCHED_FIFO, &param) != 0)
     {
@@ -96,12 +90,8 @@ void set_realtime_priority(void)
         log_info("Scheduler set to SCHED_FIFO, priority %d", param.sched_priority);
     }
 
-    // Reduce timer slack from the kernel default (50us) to 1ns. The slack is
-    // a window the kernel can delay a timer wakeup within to coalesce wakeups
-    // for power saving; for the cyclic PLC thread waiting on
-    // clock_nanosleep(TIMER_ABSTIME) it directly translates to jitter on the
-    // cycle boundary. PR_SET_TIMERSLACK is per-thread, so this only affects
-    // the calling (PLC scan) thread.
+    // Default timer slack (50us) directly becomes wake-up jitter on
+    // clock_nanosleep(TIMER_ABSTIME). PR_SET_TIMERSLACK is per-thread.
     if (prctl(PR_SET_TIMERSLACK, 1UL, 0, 0, 0) != 0)
     {
         log_warn("PR_SET_TIMERSLACK failed: %s", strerror(errno));

--- a/core/src/plc_app/utils/utils.c
+++ b/core/src/plc_app/utils/utils.c
@@ -15,6 +15,7 @@
 #if !defined(__CYGWIN__) && !defined(__MSYS__)
 #include <sched.h>
 #include <sys/mman.h>
+#include <sys/prctl.h>
 #define HAS_REALTIME_FEATURES 1
 #else
 #define HAS_REALTIME_FEATURES 0
@@ -128,6 +129,21 @@ void set_realtime_priority(void)
                 }
             }
         }
+    }
+
+    // Reduce timer slack from the kernel default (50us) to 1ns. The slack is
+    // a window the kernel can delay a timer wakeup within to coalesce wakeups
+    // for power saving; for the cyclic PLC thread waiting on
+    // clock_nanosleep(TIMER_ABSTIME) it directly translates to jitter on the
+    // cycle boundary. PR_SET_TIMERSLACK is per-thread, so this only affects
+    // the calling (PLC scan) thread.
+    if (prctl(PR_SET_TIMERSLACK, 1UL, 0, 0, 0) != 0)
+    {
+        log_warn("PR_SET_TIMERSLACK failed: %s", strerror(errno));
+    }
+    else
+    {
+        log_info("Timer slack reduced to 1ns for PLC thread");
     }
 #else
     // Real-time scheduling not available on MSYS2/Cygwin

--- a/core/src/plc_app/utils/utils.c
+++ b/core/src/plc_app/utils/utils.c
@@ -73,7 +73,14 @@ void timespec_diff(struct timespec *a, struct timespec *b, struct timespec *resu
     }
 }
 
-// configure SCHED_FIFO priority and pin to the highest-numbered CPU core
+// Configure SCHED_FIFO priority and reduce timer slack on the PLC scan thread.
+//
+// CPU affinity / pinning is intentionally NOT applied here. Pinning to a
+// specific core is a deployment concern (which CPU is isolated, whether the
+// host has multiple physical packages, container cpuset restrictions, etc.)
+// and the runtime should stay hardware-agnostic. Operators control affinity
+// at deployment time via taskset, cgroup cpuset, container --cpuset-cpus, or
+// the `CPUAffinity=` directive of the systemd service unit.
 void set_realtime_priority(void)
 {
 #if HAS_REALTIME_FEATURES
@@ -87,48 +94,6 @@ void set_realtime_priority(void)
     else
     {
         log_info("Scheduler set to SCHED_FIFO, priority %d", param.sched_priority);
-    }
-
-    // Pin PLC thread to the highest-numbered CPU core.
-    // On a 4-core system (0-3) this selects core 3, which is the best
-    // candidate for isolation (isolcpus= boot parameter).
-    // If the core is not available (e.g. Docker --cpuset-cpus restricts
-    // the set), fall back to the last available core in the affinity mask.
-    int num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
-    if (num_cpus > 1)
-    {
-        cpu_set_t available;
-        CPU_ZERO(&available);
-        if (sched_getaffinity(0, sizeof(available), &available) == 0)
-        {
-            // Find the highest available core
-            int target_cpu = -1;
-            for (int i = num_cpus - 1; i >= 0; i--)
-            {
-                if (CPU_ISSET(i, &available))
-                {
-                    target_cpu = i;
-                    break;
-                }
-            }
-
-            if (target_cpu >= 0)
-            {
-                cpu_set_t cpuset;
-                CPU_ZERO(&cpuset);
-                CPU_SET(target_cpu, &cpuset);
-                if (pthread_setaffinity_np(pthread_self(), sizeof(cpuset), &cpuset) == 0)
-                {
-                    log_info("PLC thread pinned to CPU %d (of %d available)",
-                             target_cpu, num_cpus);
-                }
-                else
-                {
-                    log_warn("Failed to pin PLC thread to CPU %d: %s",
-                             target_cpu, strerror(errno));
-                }
-            }
-        }
     }
 
     // Reduce timer slack from the kernel default (50us) to 1ns. The slack is


### PR DESCRIPTION
## Summary

Four changes to reduce worst-case jitter of the synchronous EtherCAT exchange on PREEMPT_RT and harden the plugin's interactions with system tools.

### 1. Defer SCHED_FIFO promotion until after plugin/program init
*(`core/src/plc_app/plc_state_manager.c`, `core/src/plc_app/utils/utils.c`)*

`plc_cycle_thread` used to go `SCHED_FIFO 20` **before** `plugin_driver_start()`. With `PTHREAD_INHERIT_SCHED` (the pthread default) every thread spawned during plugin start (unix socket helpers, log streamer, EtherCAT monitor, Python `runner_thread`) silently inherited FIFO 20 and contended with the scan on whatever core the deployment had pinned the runtime to.

Moving `set_realtime_priority()` to right before the cyclic loop ensures only the scan thread is RT. `lock_memory()` stays early (`mlockall` is process-wide and idempotent). CPU affinity is no longer set inside the runtime — it is left to deployment (`taskset`, cgroup cpuset, systemd `CPUAffinity=`) so the runtime stays hardware-agnostic.

### 2. Reduce timer slack on the PLC scan thread
*(`core/src/plc_app/utils/utils.c`)*

The kernel default (50 us) directly translates to wake-up jitter on `clock_nanosleep(TIMER_ABSTIME)`. `PR_SET_TIMERSLACK` is per-thread.

### 3. Silence the IP stack on the EtherCAT NIC while operational
*(`core/src/drivers/plugins/native/ethercat/ethercat_plugin.c`)*

SOEM uses `AF_PACKET`, but the kernel still processes ARP/IPv6-NS/multicast/broadcast on any iface with IP enabled.

`start_single_master()` disables IPv6 on the iface (only if it was on) and inserts `iptables -I INPUT 1 -i <iface> -j DROP`. `stop_single_master()` reverts both, tracking per-master what was applied so operator config is never clobbered. Failures (e.g. `iptables` missing) are non-fatal warns.

### 4. Refactor: drop shell-out, share iface validator, persist isolation state
*(new `ethercat_proc.{c,h}`; `ethercat_config.{c,h}`, `ethercat_master.c`, `ethercat_plugin.c`)*

Every NIC interaction in the plugin (existing `tune_nic`/`restore_nic_settings` and the new `apply_iface_isolation`) interpolated the iface name into a shell command. The iface name comes from JSON uploaded via the API, so this is a real injection surface.

- New `ecat_run_argv()` helper uses `fork`+`execvp`, argv passed verbatim — no shell, no injection.
- `validate_iface_name` (was static) promoted to public `ecat_is_valid_iface_name`; all four call sites now share one definition.
- Iface-isolation state (iptables rule + IPv6 flip) persisted per-iface to `/run/runtime/ecat_iface_iso_<iface>.state` via atomic temp+rename, mirroring the existing NIC-settings persistence. On the next start, leftover state from a crashed prior run is reverted before fresh state is applied — SIGKILL/OOM no longer leak across lifecycles.

## Test plan

- [x] Build cleanly (`plc_main` and `libethercat_plugin.so`).
- [x] Confirm only the scan thread is in `SCHED_FIFO`:
      `ps -T -o tid,cls,rtprio,psr,comm -p $(pgrep -x plc_main)`
- [x] Log shows `Timer slack reduced to 1ns`, `disabled IPv6 on <iface>`, `inserted iptables INPUT DROP for <iface>`.
- [x] On `stop_loop`, the rule is removed and IPv6 is restored (only when flipped by the plugin). Repeated start/stop cycles do not stack rules.
- [x] Plugin still operates if `iptables` is not installed.
- [x] **Crash recovery**: `kill -9 $(pgrep -x plc_main)` while running; confirm `/run/runtime/ecat_iface_iso_<iface>.state` exists. Restart; verify the `Found stale iface-isolation state ... reverting` warn, the rule is gone, and IPv6 was reset before fresh apply.
- [x] **Bad iface name**: a configured iface with shell metacharacters is rejected with `interface '...' is not a valid Linux iface name - skipping IP-stack isolation` (no injection).
- [x] Cyclic-exchange benchmark on a representative bus vs baseline.

## Notes for review

- All NIC tooling (`ethtool`, `iptables`) goes through `fork`+`execvp` with explicit argv — no shell, no injection even if a malicious iface name were configured.
- `apply_iface_isolation` / `revert_iface_isolation` only touch `iptables` and `/proc/sys/net/ipv6/conf/<iface>/disable_ipv6`. No new privilege surface (root already required).
- Multi-master sharing one iface: second `stop_loop` removes the rule before the first stops — acceptable edge case for supported topologies.
- `/run/runtime/` is tmpfs; reset on reboot, orthogonal to the existing `ecat_nic_saved_<iface>.conf` files.
- CPU affinity is no longer the runtime's concern; deployments that need core isolation should configure it via `taskset`, cgroup cpuset, or systemd `CPUAffinity=` (combined with kernel `isolcpus=`/`nohz_full=`/`rcu_nocbs=` if desired).
- Rolling back: two commits, no schema/IPC changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)