### PR TITLE
feat(discovery): UDP LAN discovery responder for editor device search

### DIFF
--- a/tests/pytest/discovery/test_network_discovery.py
+++ b/tests/pytest/discovery/test_network_discovery.py
@@ -1,0 +1,122 @@
+"""Unit tests for the UDP network discovery responder."""
+
+from __future__ import annotations
+
+import json
+import socket
+import time
+
+import pytest
+
+from webserver.discovery.network_discovery import (
+    DISCOVERY_MAGIC,
+    MAX_REQUEST_BYTES,
+    NetworkDiscoveryResponder,
+    PER_IP_RATE_LIMIT_SECONDS,
+)
+
+
+def _ephemeral_port() -> int:
+    """Return a free UDP port to avoid clashing with anything else."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture
+def running_responder():
+    """Start a responder on a fresh ephemeral port; tear it down afterwards."""
+    port = _ephemeral_port()
+    responder = NetworkDiscoveryResponder(port=port)
+    assert responder.start() is True
+    # Give the listener thread a moment to enter recvfrom.
+    time.sleep(0.05)
+    yield responder, port
+    responder.stop()
+
+
+def _probe(port: int, payload: bytes, timeout: float = 0.5) -> bytes | None:
+    """Send a UDP packet to the responder and read any reply.
+
+    Returns the reply bytes or None if nothing arrived before timeout.
+    """
+    client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    client.settimeout(timeout)
+    try:
+        client.bind(("127.0.0.1", 0))
+        client.sendto(payload, ("127.0.0.1", port))
+        try:
+            data, _ = client.recvfrom(4096)
+            return data
+        except socket.timeout:
+            return None
+    finally:
+        client.close()
+
+
+class TestNetworkDiscoveryResponder:
+    """End-to-end behaviour of the discovery responder."""
+
+    def test_valid_magic_returns_json_payload(self, running_responder):
+        _, port = running_responder
+        reply = _probe(port, DISCOVERY_MAGIC)
+
+        assert reply is not None, "responder did not reply to valid magic"
+
+        decoded = json.loads(reply.decode("utf-8"))
+        assert decoded["service"] == "openplc-runtime"
+        assert decoded["protocol_version"] == 1
+        assert decoded["api_port"] == 8443
+        assert isinstance(decoded["runtime_version"], str)
+        assert isinstance(decoded["hostname"], str)
+        assert decoded["hostname"]  # non-empty
+
+    def test_garbage_input_is_dropped(self, running_responder):
+        _, port = running_responder
+        reply = _probe(port, b"hello world", timeout=0.3)
+        assert reply is None
+
+    def test_oversized_packet_is_dropped(self, running_responder):
+        _, port = running_responder
+        oversized = DISCOVERY_MAGIC + b"X" * (MAX_REQUEST_BYTES + 32)
+        reply = _probe(port, oversized, timeout=0.3)
+        assert reply is None
+
+    def test_magic_with_trailing_whitespace_is_accepted(self, running_responder):
+        """Stripping protects against accidental newline-suffixed probes."""
+        _, port = running_responder
+        reply = _probe(port, DISCOVERY_MAGIC + b"\n")
+        assert reply is not None
+
+    def test_rate_limit_drops_rapid_repeats(self, running_responder):
+        _, port = running_responder
+
+        first = _probe(port, DISCOVERY_MAGIC)
+        assert first is not None
+
+        # Same source IP, well within the rate-limit window.
+        second = _probe(port, DISCOVERY_MAGIC, timeout=0.2)
+        assert second is None
+
+        # After waiting past the window, the next request goes through.
+        time.sleep(PER_IP_RATE_LIMIT_SECONDS + 0.05)
+        third = _probe(port, DISCOVERY_MAGIC)
+        assert third is not None
+
+    def test_bind_failure_returns_false(self):
+        """Binding the same port twice should fail gracefully."""
+        port = _ephemeral_port()
+        primary = NetworkDiscoveryResponder(port=port)
+        assert primary.start() is True
+
+        try:
+            secondary = NetworkDiscoveryResponder(port=port)
+            # SO_REUSEPORT on Linux may allow rebinding; treat either
+            # outcome as acceptable as long as it doesn't raise.
+            result = secondary.start()
+            assert result in (True, False)
+            secondary.stop()
+        finally:
+            primary.stop()

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -24,6 +24,7 @@ import flask_login
 from webserver.credentials import CertGen
 from webserver.debug_websocket import init_debug_websocket
 from webserver.discovery.discovery_routes import discovery_bp
+from webserver.discovery.network_discovery import responder as network_discovery_responder
 from webserver.logger import get_logger
 from webserver.plcapp_management import (
     MAX_FILE_SIZE,
@@ -59,6 +60,11 @@ runtime_manager = RuntimeManager(
 )
 
 runtime_manager.start()
+
+# UDP discovery responder so the editor can find this runtime on the LAN.
+# Failure to bind is logged and ignored — discovery is a convenience, not a
+# hard dependency.
+network_discovery_responder.start()
 
 # Store in Flask app config so blueprints can access via current_app
 # without triggering a re-import of this module (which would create
@@ -386,6 +392,7 @@ def run_https():
     finally:
         logger.info("Runtime manager stopped")
         runtime_manager.stop()
+        network_discovery_responder.stop()
 
 
 if __name__ == "__main__":

--- a/webserver/discovery/network_discovery.py
+++ b/webserver/discovery/network_discovery.py
@@ -1,0 +1,203 @@
+"""UDP network discovery responder.
+
+Listens on UDP port 33333 for the magic string ``OPENPLC_DISCOVER_V1``
+and answers each requester with a JSON record describing this runtime
+instance.  Designed so the OpenPLC Editor can find headless runtimes
+on a LAN without the user having to know their IP addresses.
+
+The protocol is intentionally tiny and stateless:
+
+    Request   : "OPENPLC_DISCOVER_V1"          (UTF-8, exact)
+    Response  : JSON with {service, protocol_version, runtime_version,
+                           hostname, api_port}
+
+Only the magic string is accepted; anything else is dropped silently.
+Replies are unicast to the source address of the request, which is
+the authoritative way to learn the runtime's reachable IP (the
+runtime itself may not know its outward-facing address on hosts with
+multiple interfaces).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+from typing import Optional
+
+from webserver.logger import get_logger
+from webserver.version import RUNTIME_VERSION
+
+DISCOVERY_PORT: int = 33333
+DISCOVERY_MAGIC: bytes = b"OPENPLC_DISCOVER_V1"
+PROTOCOL_VERSION: int = 1
+API_PORT: int = 8443
+
+# Drop oversized packets without parsing them.  The magic string is
+# 19 bytes; 64 bytes is plenty of slack for future protocol revisions
+# without inviting amplification probes.
+MAX_REQUEST_BYTES: int = 64
+
+# Per-source-IP rate limit, in seconds.  Each remote IP can only
+# trigger a reply this often; spammier probes get silently dropped.
+# Discovery is a manual, user-driven action — a generous floor here
+# still feels instant from the editor side.
+PER_IP_RATE_LIMIT_SECONDS: float = 0.1
+
+logger, _ = get_logger("discovery")
+
+
+class NetworkDiscoveryResponder:
+    """UDP responder that advertises this runtime on the LAN.
+
+    Run as a daemon thread alongside the Flask server.  Bind failures
+    (e.g. port already in use) are logged and swallowed so a misconfig
+    cannot block runtime startup.
+    """
+
+    def __init__(self, port: int = DISCOVERY_PORT) -> None:
+        self.port = port
+        self._sock: Optional[socket.socket] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._last_seen: dict[str, float] = {}
+
+    def start(self) -> bool:
+        """Start the responder thread.  Returns True on success."""
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            # SO_REUSEPORT is Linux/BSD only — best-effort on other OSes.
+            if hasattr(socket, "SO_REUSEPORT"):
+                try:
+                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+                except (AttributeError, OSError):
+                    pass
+            sock.bind(("0.0.0.0", self.port))
+            # Short recv timeout so the stop event is observed promptly.
+            sock.settimeout(0.5)
+        except OSError as exc:
+            logger.warning(
+                "Discovery responder could not bind UDP %d: %s. "
+                "Editor LAN search will not find this runtime.",
+                self.port,
+                exc,
+            )
+            return False
+
+        self._sock = sock
+        self._thread = threading.Thread(
+            target=self._run, name="network-discovery", daemon=True
+        )
+        self._thread.start()
+        # WARNING level so it surfaces with default log filtering.
+        logger.warning(
+            "[DISCOVERY] Responder listening on UDP %d (hostname=%s)",
+            self.port,
+            socket.gethostname(),
+        )
+        return True
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+
+    def _run(self) -> None:
+        assert self._sock is not None
+        while not self._stop_event.is_set():
+            try:
+                data, addr = self._sock.recvfrom(MAX_REQUEST_BYTES + 1)
+            except socket.timeout:
+                continue
+            except OSError:
+                # Socket closed during shutdown.
+                break
+
+            self._handle(data, addr)
+
+    def _handle(self, data: bytes, addr: tuple[str, int]) -> None:
+        src_ip = addr[0]
+        src_port = addr[1]
+
+        # Strict input filter: exact magic only, anything else dropped.
+        if len(data) > MAX_REQUEST_BYTES:
+            logger.warning(
+                "[DISCOVERY] Dropping oversized packet from %s:%d (%d bytes)",
+                src_ip,
+                src_port,
+                len(data),
+            )
+            return
+        if data.strip() != DISCOVERY_MAGIC:
+            # Log a short, safe preview — never echo raw bytes back out.
+            preview = data[:32].decode("utf-8", errors="replace")
+            logger.warning(
+                "[DISCOVERY] Dropping packet from %s:%d (%d bytes, not the magic). Preview: %r",
+                src_ip,
+                src_port,
+                len(data),
+                preview,
+            )
+            return
+
+        logger.warning(
+            "[DISCOVERY] Received probe from %s:%d (%d bytes)",
+            src_ip,
+            src_port,
+            len(data),
+        )
+
+        now = time.monotonic()
+        last = self._last_seen.get(src_ip, 0.0)
+        if now - last < PER_IP_RATE_LIMIT_SECONDS:
+            logger.warning(
+                "[DISCOVERY] Rate-limit drop for %s (last reply %.3fs ago)",
+                src_ip,
+                now - last,
+            )
+            return
+        self._last_seen[src_ip] = now
+
+        # Garbage-collect the rate-limit cache occasionally so a long-
+        # running runtime doesn't accumulate state from drive-by probes.
+        if len(self._last_seen) > 1024:
+            cutoff = now - 60.0
+            self._last_seen = {
+                ip: ts for ip, ts in self._last_seen.items() if ts >= cutoff
+            }
+
+        payload = json.dumps(
+            {
+                "service": "openplc-runtime",
+                "protocol_version": PROTOCOL_VERSION,
+                "runtime_version": RUNTIME_VERSION,
+                "hostname": socket.gethostname(),
+                "api_port": API_PORT,
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+        try:
+            assert self._sock is not None
+            sent = self._sock.sendto(payload, addr)
+            logger.warning(
+                "[DISCOVERY] Sent reply to %s:%d (%d/%d bytes)",
+                src_ip,
+                src_port,
+                sent,
+                len(payload),
+            )
+        except OSError as exc:
+            logger.warning(
+                "[DISCOVERY] Reply to %s:%d failed: %s", src_ip, src_port, exc
+            )
+
+
+# Module-level singleton used by webserver/app.py.
+responder = NetworkDiscoveryResponder()

--- a/webserver/discovery/network_discovery.py
+++ b/webserver/discovery/network_discovery.py
@@ -91,12 +91,7 @@ class NetworkDiscoveryResponder:
             target=self._run, name="network-discovery", daemon=True
         )
         self._thread.start()
-        # WARNING level so it surfaces with default log filtering.
-        logger.warning(
-            "[DISCOVERY] Responder listening on UDP %d (hostname=%s)",
-            self.port,
-            socket.gethostname(),
-        )
+        logger.info("Discovery responder listening on UDP %d", self.port)
         return True
 
     def stop(self) -> None:
@@ -122,45 +117,14 @@ class NetworkDiscoveryResponder:
             self._handle(data, addr)
 
     def _handle(self, data: bytes, addr: tuple[str, int]) -> None:
-        src_ip = addr[0]
-        src_port = addr[1]
-
         # Strict input filter: exact magic only, anything else dropped.
-        if len(data) > MAX_REQUEST_BYTES:
-            logger.warning(
-                "[DISCOVERY] Dropping oversized packet from %s:%d (%d bytes)",
-                src_ip,
-                src_port,
-                len(data),
-            )
-            return
-        if data.strip() != DISCOVERY_MAGIC:
-            # Log a short, safe preview — never echo raw bytes back out.
-            preview = data[:32].decode("utf-8", errors="replace")
-            logger.warning(
-                "[DISCOVERY] Dropping packet from %s:%d (%d bytes, not the magic). Preview: %r",
-                src_ip,
-                src_port,
-                len(data),
-                preview,
-            )
+        if len(data) > MAX_REQUEST_BYTES or data.strip() != DISCOVERY_MAGIC:
             return
 
-        logger.warning(
-            "[DISCOVERY] Received probe from %s:%d (%d bytes)",
-            src_ip,
-            src_port,
-            len(data),
-        )
-
+        src_ip = addr[0]
         now = time.monotonic()
         last = self._last_seen.get(src_ip, 0.0)
         if now - last < PER_IP_RATE_LIMIT_SECONDS:
-            logger.warning(
-                "[DISCOVERY] Rate-limit drop for %s (last reply %.3fs ago)",
-                src_ip,
-                now - last,
-            )
             return
         self._last_seen[src_ip] = now
 
@@ -185,18 +149,9 @@ class NetworkDiscoveryResponder:
 
         try:
             assert self._sock is not None
-            sent = self._sock.sendto(payload, addr)
-            logger.warning(
-                "[DISCOVERY] Sent reply to %s:%d (%d/%d bytes)",
-                src_ip,
-                src_port,
-                sent,
-                len(payload),
-            )
+            self._sock.sendto(payload, addr)
         except OSError as exc:
-            logger.warning(
-                "[DISCOVERY] Reply to %s:%d failed: %s", src_ip, src_port, exc
-            )
+            logger.debug("Discovery reply to %s failed: %s", src_ip, exc)
 
 
 # Module-level singleton used by webserver/app.py.


### PR DESCRIPTION
## Summary
- Adds a stateless UDP responder on port 33333 that lets the OpenPLC Editor discover headless runtime installs on a LAN.
- Responder validates an `OPENPLC_DISCOVER_V1` magic string and replies with `{service, protocol_version, runtime_version, hostname, api_port}`.
- Includes per-source rate limiting, oversized-packet rejection, graceful bind-failure handling so a misconfigured port can't block runtime startup.
- Started as a daemon thread alongside the Flask server in `webserver/app.py`.

## Test plan
- [x] `pytest tests/pytest/discovery/test_network_discovery.py` — 6 tests pass (valid magic, garbage drop, oversized drop, whitespace tolerance, rate limit, bind failure)
- [x] Manual smoke test on a headless device with the editor (`feat/runtime-network-discovery`) finding it via the new "Search for devices" button on Board Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)