### PR TITLE
Release v4.1.2 — Windows installer build fix

### DIFF
--- a/core/src/drivers/plugins/native/ethercat/CMakeLists.txt
+++ b/core/src/drivers/plugins/native/ethercat/CMakeLists.txt
@@ -60,8 +60,21 @@ target_compile_options(soem PUBLIC\n\
 # HAVE_U_INT*_T tells bundled bittypes.h to skip its typedefs --\n\
 # MSYS2 POSIX headers (sys/types.h) already provide these types and\n\
 # use different underlying types on LP64 (long vs long long for 64-bit).\n\
+#\n\
+# __USE_W32_SOCKETS tells MSYS2 / Cygwin's POSIX headers\n\
+# (\`sys/select.h\`, \`sys/unistd.h\`) NOT to declare their own \`select\`\n\
+# and \`gethostname\` — the Win32 \`winsock2.h\` declarations (which the\n\
+# bundled wpcap headers pull in transitively) are the ones we want\n\
+# to use.  Without this, any TU that includes both a POSIX header\n\
+# (e.g. \`<signal.h>\` in ethercat_plugin.c, which transitively pulls\n\
+# in sys/select.h) AND a SOEM/wpcap header (which pulls in\n\
+# winsock2.h) gets a redeclaration error because the two libcs\n\
+# disagree on the signature ( \`struct timeval *\` vs \`const TIMEVAL *\`,\n\
+# \`size_t\` vs \`int\`).  Marking the macro PUBLIC propagates it to\n\
+# every target linking against soem (notably ethercat_plugin).\n\
 target_compile_definitions(soem PUBLIC\n\
   WIN32\n\
+  __USE_W32_SOCKETS\n\
   HAVE_U_INT8_T\n\
   HAVE_U_INT16_T\n\
   HAVE_U_INT32_T\n\

--- a/core/src/plc_app/image_tables.cpp
+++ b/core/src/plc_app/image_tables.cpp
@@ -93,7 +93,16 @@ namespace {
     {
         pthread_mutexattr_t attr;
         if (pthread_mutexattr_init(&attr) != 0) return -1;
+        // Priority inheritance is a POSIX optional feature.  MSYS2/Cygwin
+        // pthread on Windows doesn't ship it (PTHREAD_PRIO_INHERIT is
+        // undefined, pthread_mutexattr_setprotocol is unavailable).
+        // Windows has no real-time scheduling anyway, so the PI protocol
+        // would be a no-op even if it linked — fall back to a plain
+        // recursive mutex.
+#if !defined(__CYGWIN__) && !defined(__MSYS__) && \
+    defined(_POSIX_THREAD_PRIO_INHERIT) && _POSIX_THREAD_PRIO_INHERIT > 0
         pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT);
+#endif
         pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
         int rc = pthread_mutex_init(m, &attr);
         pthread_mutexattr_destroy(&attr);

--- a/core/src/plc_app/plc_state_manager.cpp
+++ b/core/src/plc_app/plc_state_manager.cpp
@@ -140,6 +140,13 @@ static void *plc_task_thread(void *arg)
 
     if (ctx->cpu_affinity_mask != 0)
     {
+        // CPU affinity uses `cpu_set_t` / `CPU_ZERO` / `CPU_SETSIZE` /
+        // `pthread_setaffinity_np` — all Linux extensions to `<sched.h>`,
+        // not present on MSYS2/Cygwin/Windows.  Skip silently when
+        // building for a non-Linux host: Windows doesn't expose
+        // SCHED_FIFO either, so any "pin to CPU" guarantee would already
+        // be unachievable there.
+#if !defined(__CYGWIN__) && !defined(__MSYS__) && defined(__linux__)
         cpu_set_t cs;
         CPU_ZERO(&cs);
         for (int cpu = 0; cpu < 64 && cpu < CPU_SETSIZE; ++cpu)
@@ -151,6 +158,10 @@ static void *plc_task_thread(void *arg)
             log_warn("[task %s] pthread_setaffinity_np failed: %s",
                      ctx->name, strerror(errno));
         }
+#else
+        log_info("[task %s] CPU affinity requested but unsupported on this platform",
+                 ctx->name);
+#endif
     }
 
     if (sigsetjmp(ctx->crash_jmp, 1) != 0)

--- a/install.sh
+++ b/install.sh
@@ -466,6 +466,17 @@ build_native_plugins() {
     local plugins_built=0
     local plugins_failed=0
 
+    # Plugins that require Linux-only kernel features (SCHED_FIFO,
+    # PREEMPT_RT, raw sockets via libpcap with kernel bypass) — skip
+    # them entirely on MSYS2/Windows.  The vendored SOEM EtherCAT
+    # master in particular ships its own Windows port (under
+    # `oshw/win32/wpcap/`) that conflicts with MSYS2's w32api
+    # `winsock2.h` (duplicate definitions of `select`, `gethostname`,
+    # etc.), and even if those headers compiled cleanly the runtime
+    # behaviour relies on PREEMPT_RT scheduling that Windows doesn't
+    # provide.  These plugins are Linux-only by design.
+    local linux_only_plugins=("ethercat")
+
     for plugin_dir in "$native_plugins_dir"/*/; do
         # Skip if not a directory
         [ -d "$plugin_dir" ] || continue
@@ -476,6 +487,21 @@ build_native_plugins() {
         # Skip if no CMakeLists.txt
         if [ ! -f "$cmake_file" ]; then
             continue
+        fi
+
+        # Skip Linux-only plugins on MSYS2/Windows
+        if is_msys2; then
+            local is_linux_only=0
+            for skip in "${linux_only_plugins[@]}"; do
+                if [ "$plugin_name" = "$skip" ]; then
+                    is_linux_only=1
+                    break
+                fi
+            done
+            if [ "$is_linux_only" = "1" ]; then
+                log_info "Skipping Linux-only plugin on MSYS2/Windows: $plugin_name"
+                continue
+            fi
         fi
 
         plugins_found=$((plugins_found + 1))

--- a/install.sh
+++ b/install.sh
@@ -466,17 +466,6 @@ build_native_plugins() {
     local plugins_built=0
     local plugins_failed=0
 
-    # Plugins that require Linux-only kernel features (SCHED_FIFO,
-    # PREEMPT_RT, raw sockets via libpcap with kernel bypass) — skip
-    # them entirely on MSYS2/Windows.  The vendored SOEM EtherCAT
-    # master in particular ships its own Windows port (under
-    # `oshw/win32/wpcap/`) that conflicts with MSYS2's w32api
-    # `winsock2.h` (duplicate definitions of `select`, `gethostname`,
-    # etc.), and even if those headers compiled cleanly the runtime
-    # behaviour relies on PREEMPT_RT scheduling that Windows doesn't
-    # provide.  These plugins are Linux-only by design.
-    local linux_only_plugins=("ethercat")
-
     for plugin_dir in "$native_plugins_dir"/*/; do
         # Skip if not a directory
         [ -d "$plugin_dir" ] || continue
@@ -487,21 +476,6 @@ build_native_plugins() {
         # Skip if no CMakeLists.txt
         if [ ! -f "$cmake_file" ]; then
             continue
-        fi
-
-        # Skip Linux-only plugins on MSYS2/Windows
-        if is_msys2; then
-            local is_linux_only=0
-            for skip in "${linux_only_plugins[@]}"; do
-                if [ "$plugin_name" = "$skip" ]; then
-                    is_linux_only=1
-                    break
-                fi
-            done
-            if [ "$is_linux_only" = "1" ]; then
-                log_info "Skipping Linux-only plugin on MSYS2/Windows: $plugin_name"
-                continue
-            fi
         fi
 
         plugins_found=$((plugins_found + 1))


### PR DESCRIPTION
## Summary

Cuts v4.1.2 with the Windows installer artefact restored.

Three commits from #133:

- **`fix(windows): guard Linux-only POSIX RT calls behind feature macros`** — `image_tables.cpp::init_recursive_pi_mutex` no longer hard-fails on MSYS2 over `PTHREAD_PRIO_INHERIT`; `plc_state_manager.cpp`'s CPU-affinity block is now Linux-only.
- **`fix(windows): define __USE_W32_SOCKETS so SOEM compiles on MSYS2`** — fixes the `select` / `gethostname` redeclaration between MSYS2's POSIX `sys/select.h`/`sys/unistd.h` and the Win32 `winsock2.h` chain pulled in by SOEM's wpcap headers.  EtherCAT plugin now compiles and ships on Windows.
- The intermediate "skip EtherCAT on MSYS2" approach was reverted; the right fix lets EtherCAT compile on Windows rather than excluding it.

Verified end-to-end in a Parallels Windows VM (same MSYS2 toolchain GHA uses) and on the GHA Windows runner via workflow_dispatch on the fix branch — both produce `libethercat_plugin.so`.

## Test plan

- [x] GHA \`Build Windows Installer\` workflow runs green on the fix branch
- [x] Full \`install.sh\` succeeds on a clean Windows VM and reports \`Built and installed: ethercat (libethercat_plugin.so)\`
- [x] Linux/Docker path unaffected — every change is gated by \`CMAKE_SYSTEM_NAME STREQUAL MSYS|CYGWIN\` or by the existing \`#if !defined(__CYGWIN__) && !defined(__MSYS__)\` pattern in utils.c
- [ ] After merge: tag v4.1.2 → release workflow publishes the Windows installer artefact alongside the Docker multi-arch image