### PR TITLE
docs: document manual VERSION-file bump per release tag

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -143,6 +143,14 @@ jobs:
         run: |
           Write-Host "Building installer..."
 
+          # NOTE: $version here only labels the installer (filename +
+          # Add/Remove Programs AppVersion). The version the RUNTIME
+          # advertises (discovery scan, /api/version) comes from the
+          # repo-root VERSION file baked into the payload, NOT from the
+          # tag. That file must be bumped by hand for every release -- see
+          # webserver/version.py. (A CI-only injection here would not help
+          # manual `git clone && ./install.sh` installs, which are common.)
+          #
           # Set version from input or tag
           $version = "${{ github.event.inputs.version }}"
           if ([string]::IsNullOrEmpty($version)) {

--- a/webserver/version.py
+++ b/webserver/version.py
@@ -19,6 +19,24 @@ Editors gate firmware uploads on this string — a ``dev`` response
 gets rejected because the editor can't tell whether the target
 speaks the STruC++ wire format.  The VERSION file fallback closes
 that hole for local installers.
+
+=============================================================================
+RELEASE STEP — DO THIS EVERY TIME YOU CUT A NEW VERSION TAG:
+=============================================================================
+Bump the repo-root ``VERSION`` file to match the new git tag BEFORE you
+tag and push.  The Docker image gets its version from the tag (build-arg
+above), but the Windows installer payload and every manual
+``git clone … && ./install.sh`` install read the ``VERSION`` file directly.
+If you forget, those installs keep advertising the OLD version — the
+discovery scan and ``/api/version`` will be wrong even though the tag is
+right.  This is a manual step on purpose: a CI-only fix (e.g. writing the
+tag into the payload) would not cover manual source installs, which are
+common.  Keep ``VERSION`` in sync with the tag by hand.
+
+NOTE: the ``VERSION`` file is read verbatim (stripped of surrounding
+whitespace only) — it must contain ONLY the version string and nothing
+else (no comments). Match the tag format exactly, e.g. ``v4.1.3``.
+=============================================================================
 """
 
 import os


### PR DESCRIPTION
## Why

The runtime advertises its version (UDP discovery scan, `/api/version`, `X-OpenPLC-Runtime-Version`) from the repo-root `VERSION` file for the **Windows installer payload** and all **manual `git clone && ./install.sh` installs**. Only the Docker image derives the version from the git tag (via a build-arg env var). So keeping `VERSION` in sync with the tag is a **manual, per-release step** — and a CI-only injection would not help the (common) manual-install path.

This bit us on v4.1.3: the tag was correct but `VERSION` was stale, so the Windows runtime advertised the old version.

## Change

Documentation only — no functional change:
- Prominent "RELEASE STEP" block in `webserver/version.py` (the code that resolves the version) telling maintainers to bump `VERSION` to match the tag before tagging, that the file is read verbatim (no comments inside it), and to match the tag format (e.g. `v4.1.3`).
- Cross-reference comment in `windows-installer.yml` near where it labels the installer, clarifying the runtime version comes from the payload `VERSION` file, not the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)