### PR TITLE
Support Modbus gateways: multiple slave IDs behind one IP

### DIFF
--- a/core/src/drivers/plugins/python/modbus_master/modbus_master_plugin.py
+++ b/core/src/drivers/plugins/python/modbus_master/modbus_master_plugin.py
@@ -433,42 +433,64 @@ class ModbusSlaveDevice(threading.Thread):
         self._stop_event.set()
 
 
-class ModbusRtuBusHandler(threading.Thread):
+class ModbusBusHandler(threading.Thread):
     """
-    Handles multiple Modbus RTU devices on a single serial port (multi-drop).
-    One thread per serial bus, managing multiple slave IDs.
+    Handles multiple Modbus devices that share ONE connection, multiplexed by
+    slave/unit ID. One thread per bus, managing multiple slave IDs over a single
+    connection. Used for two cases:
+      - RTU multi-drop: several devices on one serial port (different slave IDs).
+      - TCP gateway (TCP-to-RTU converter): several serial slaves behind one
+        IP:port, distinguished by their unit/slave ID.
 
-    This differs from ModbusSlaveDevice in that:
-    - A single serial connection is shared by multiple devices
-    - Each device has a unique slave_id
-    - IO operations include the slave_id to route to the correct device
+    This differs from ModbusSlaveDevice (one connection per device) in that:
+    - A single connection is shared by multiple devices.
+    - Each device has a unique slave_id.
+    - Each IO operation carries that slave_id (device_id / MBAP unit byte) so the
+      gateway or bus routes it to the correct slave.
+
+    The run() loop is transport-agnostic; only the connection setup differs.
     """
 
     def __init__(
         self,
-        serial_config: dict,  # {serial_port, baud_rate, parity, stop_bits, data_bits, timeout_ms}
-        devices: List[Any],  # List of ModbusDeviceConfig on this bus
+        transport: str,            # "tcp" or "rtu"
+        connection_config: dict,   # tcp: {host, port, timeout_ms};
+                                   # rtu: {serial_port, baud_rate, parity, stop_bits, data_bits, timeout_ms}
+        devices: List[Any],        # List of ModbusDeviceConfig sharing this connection
         sba: SafeBufferAccess,
         plugin_logger: PluginLogger,
     ):
         super().__init__(daemon=True)
-        self.serial_config = serial_config
+        self.transport = transport
+        self.connection_config = connection_config
         self.devices = devices
         self.sba = sba
         self.logger = plugin_logger
         self._stop_event = threading.Event()
 
-        # Create single connection for the entire bus
-        self.connection_manager = ModbusConnectionManager(
-            transport="rtu",
-            serial_port=serial_config["serial_port"],
-            baud_rate=serial_config["baud_rate"],
-            parity=serial_config["parity"],
-            stop_bits=serial_config["stop_bits"],
-            data_bits=serial_config["data_bits"],
-            timeout_ms=serial_config["timeout_ms"],
-            slave_id=1,  # Default, will use device-specific slave_id per operation
-        )
+        # Single shared connection for the whole bus/gateway. slave_id here is a
+        # placeholder; every request uses its device-specific slave_id below.
+        if transport == "tcp":
+            self.connection_manager = ModbusConnectionManager(
+                transport="tcp",
+                host=connection_config["host"],
+                port=connection_config["port"],
+                timeout_ms=connection_config["timeout_ms"],
+                slave_id=1,
+            )
+            self.name = f"ModbusTcpGateway-{connection_config['host']}:{connection_config['port']}"
+        else:
+            self.connection_manager = ModbusConnectionManager(
+                transport="rtu",
+                serial_port=connection_config["serial_port"],
+                baud_rate=connection_config["baud_rate"],
+                parity=connection_config["parity"],
+                stop_bits=connection_config["stop_bits"],
+                data_bits=connection_config["data_bits"],
+                timeout_ms=connection_config["timeout_ms"],
+                slave_id=1,  # Default, will use device-specific slave_id per operation
+            )
+            self.name = f"ModbusRtuBus-{connection_config['serial_port']}"
 
         # Build consolidated IO point list with slave_id
         # Each entry: {"point": io_point, "slave_id": device.slave_id, "device_name": device.name}
@@ -488,9 +510,8 @@ class ModbusRtuBusHandler(threading.Thread):
         ) if all_cycle_times else 1000
 
         device_names = ", ".join([d.name for d in devices])
-        self.name = f"ModbusRtuBus-{serial_config['serial_port']}"
         self.logger.info(
-            f"[{self.name}] RTU bus handler created for devices: {device_names} "
+            f"[{self.name}] bus handler created for devices: {device_names} "
             f"({len(self.all_io_points)} total IO points, GCD cycle: {self.gcd_cycle_time_ms}ms)"
         )
 
@@ -812,6 +833,10 @@ class ModbusRtuBusHandler(threading.Thread):
         self._stop_event.set()
 
 
+# Backward-compatible alias: the bus handler used to be RTU-only.
+ModbusRtuBusHandler = ModbusBusHandler
+
+
 def group_rtu_devices_by_bus(devices: List[Any]) -> dict:
     """
     Group RTU devices by serial port configuration (forming unique "buses").
@@ -861,6 +886,52 @@ def group_rtu_devices_by_bus(devices: List[Any]) -> dict:
     return buses
 
 
+def group_tcp_devices_by_endpoint(devices: List[Any]) -> dict:
+    """
+    Group TCP devices by (host, port) endpoint.
+
+    Several devices may share one endpoint when it is a Modbus gateway
+    (TCP-to-RTU converter): one IP:port fronts multiple serial slaves, each with
+    a distinct slave/unit ID. Devices on the same endpoint share a single TCP
+    connection (one ModbusBusHandler thread) and are routed by slave_id; a lone
+    device on an endpoint keeps the simpler one-thread ModbusSlaveDevice path.
+
+    Args:
+        devices: List of ModbusDeviceConfig with transport="tcp"
+
+    Returns:
+        Dictionary keyed by "host:port":
+        {
+            "host:port": {
+                "config": {host, port, timeout_ms},
+                "devices": [list of devices on this endpoint],
+            }
+        }
+    """
+    endpoints = {}
+
+    for device in devices:
+        endpoint_key = f"{device.host}:{device.port}"
+
+        if endpoint_key not in endpoints:
+            endpoints[endpoint_key] = {
+                "config": {
+                    "host": device.host,
+                    "port": device.port,
+                    "timeout_ms": device.timeout_ms,
+                },
+                "devices": [],
+            }
+
+        endpoints[endpoint_key]["devices"].append(device)
+
+        # Use minimum timeout across all devices sharing the endpoint
+        if device.timeout_ms < endpoints[endpoint_key]["config"]["timeout_ms"]:
+            endpoints[endpoint_key]["config"]["timeout_ms"] = device.timeout_ms
+
+    return endpoints
+
+
 def init(args_capsule):
     """
     Initialize the Modbus Master plugin.
@@ -896,8 +967,11 @@ def start_loop():
     Start the main loop for all configured Modbus devices.
     This function is called after successful initialization.
 
-    TCP devices: One thread per device (ModbusSlaveDevice)
-    RTU devices: One thread per serial bus (ModbusRtuBusHandler), supporting multi-drop
+    TCP devices: grouped by (host, port). A lone device on an endpoint runs as
+      ModbusSlaveDevice (one connection); multiple devices on one endpoint (a
+      Modbus gateway / TCP-to-RTU converter) share one connection via
+      ModbusBusHandler, multiplexed by slave/unit ID.
+    RTU devices: One thread per serial bus (ModbusBusHandler), supporting multi-drop.
     """
     global slave_threads, modbus_master_config, safe_buffer_accessor, logger
 
@@ -937,18 +1011,44 @@ def start_loop():
 
         logger.info(f"Found {len(tcp_devices)} TCP device(s) and {len(rtu_devices)} RTU device(s)")
 
-        # Start TCP devices (one thread per device - existing behavior)
-        for device_config in tcp_devices:
-            try:
-                device_thread = ModbusSlaveDevice(device_config, safe_buffer_accessor, logger)
-                device_thread.start()
-                slave_threads.append(device_thread)
-                logger.info(
-                    f"Started TCP thread for device: {device_config.name} "
-                    f"({device_config.host}:{device_config.port}, slave_id={device_config.slave_id})"
-                )
-            except Exception as e:
-                logger.error(f"Failed to start TCP thread for device {device_config.name}: {e}")
+        # Group TCP devices by (host, port). A lone device on an endpoint keeps
+        # the simple one-thread-per-device path; multiple devices on one endpoint
+        # (a Modbus gateway / TCP-to-RTU converter) share a single TCP connection
+        # and are multiplexed by slave/unit ID via ModbusBusHandler.
+        if tcp_devices:
+            tcp_endpoints = group_tcp_devices_by_endpoint(tcp_devices)
+            logger.info(f"TCP devices grouped into {len(tcp_endpoints)} endpoint(s)")
+
+            for endpoint_key, endpoint_info in tcp_endpoints.items():
+                endpoint_devices = endpoint_info["devices"]
+                try:
+                    if len(endpoint_devices) == 1:
+                        device_config = endpoint_devices[0]
+                        device_thread = ModbusSlaveDevice(device_config, safe_buffer_accessor, logger)
+                        device_thread.start()
+                        slave_threads.append(device_thread)
+                        logger.info(
+                            f"Started TCP thread for device: {device_config.name} "
+                            f"({device_config.host}:{device_config.port}, slave_id={device_config.slave_id})"
+                        )
+                    else:
+                        gateway_thread = ModbusBusHandler(
+                            transport="tcp",
+                            connection_config=endpoint_info["config"],
+                            devices=endpoint_devices,
+                            sba=safe_buffer_accessor,
+                            plugin_logger=logger,
+                        )
+                        gateway_thread.start()
+                        slave_threads.append(gateway_thread)
+                        device_names = ", ".join([d.name for d in endpoint_devices])
+                        slave_ids = ", ".join([str(d.slave_id) for d in endpoint_devices])
+                        logger.info(
+                            f"Started TCP gateway thread: {endpoint_key} "
+                            f"(devices: {device_names}, slave_ids: {slave_ids})"
+                        )
+                except Exception as e:
+                    logger.error(f"Failed to start TCP thread(s) for endpoint {endpoint_key}: {e}")
 
         # Group RTU devices by serial port configuration
         if rtu_devices:
@@ -958,8 +1058,9 @@ def start_loop():
             # Start RTU bus handlers (one thread per serial port)
             for bus_key, bus_info in rtu_buses.items():
                 try:
-                    bus_thread = ModbusRtuBusHandler(
-                        serial_config=bus_info["config"],
+                    bus_thread = ModbusBusHandler(
+                        transport="rtu",
+                        connection_config=bus_info["config"],
                         devices=bus_info["devices"],
                         sba=safe_buffer_accessor,
                         plugin_logger=logger,

--- a/core/src/drivers/plugins/python/shared/plugin_config_decode/modbus_master_config_model.py
+++ b/core/src/drivers/plugins/python/shared/plugin_config_decode/modbus_master_config_model.py
@@ -236,10 +236,20 @@ class ModbusMasterConfig(PluginConfigContract):
         tcp_devices = [d for d in self.devices if d.transport == "tcp"]
         rtu_devices = [d for d in self.devices if d.transport == "rtu"]
 
-        # Check for duplicate host:port combinations for TCP devices
-        host_port_combinations = [(device.host, device.port) for device in tcp_devices]
-        if len(host_port_combinations) != len(set(host_port_combinations)):
-            raise ValueError("Duplicate host:port combinations found for TCP devices. Each TCP device must have a unique host:port combination.")
+        # Multiple TCP devices may share the same host:port — that is exactly how
+        # an Ethernet-to-Modbus gateway (TCP-to-RTU converter) is addressed: one IP,
+        # several serial slaves distinguished by their unit/slave ID. So we key TCP
+        # devices by (host, port, slave_id) and reject only TRUE duplicates (same
+        # endpoint AND slave ID), which would be ambiguous. The runtime routes each
+        # device's slave_id into the MBAP unit-ID byte and shares one TCP connection
+        # per host:port (see group_tcp_devices_by_endpoint / ModbusBusHandler).
+        tcp_endpoints = [(device.host, device.port, device.slave_id) for device in tcp_devices]
+        if len(tcp_endpoints) != len(set(tcp_endpoints)):
+            raise ValueError(
+                "Duplicate (host, port, slave_id) found for TCP devices. Multiple "
+                "devices may share a host:port (a Modbus gateway) only if their "
+                "slave IDs differ."
+            )
 
         # Check for duplicate slave IDs on the same serial bus for RTU devices
         # Group RTU devices by serial bus (serial_port + baud_rate + parity + stop_bits + data_bits)

--- a/tests/pytest/modbus_master/test_modbus_gateway.py
+++ b/tests/pytest/modbus_master/test_modbus_gateway.py
@@ -1,0 +1,114 @@
+"""
+Tests for Modbus TCP gateway support: multiple slaves behind one IP:port.
+
+A Modbus gateway (TCP-to-RTU converter) fronts several serial slaves on one
+IP:port, distinguished by slave/unit ID. The runtime must (a) accept multiple
+TCP devices that share a host:port as long as their slave IDs differ, and
+(b) group them onto a single shared connection (one ModbusBusHandler), routing
+each by slave_id.
+"""
+
+import pytest
+
+from core.src.drivers.plugins.python.shared.plugin_config_decode.modbus_master_config_model import (
+    ModbusMasterConfig,
+    ModbusDeviceConfig,
+)
+from core.src.drivers.plugins.python.modbus_master.modbus_master_plugin import (
+    group_tcp_devices_by_endpoint,
+)
+
+
+def _tcp_device(name, host="192.168.1.50", port=502, slave_id=1):
+    return ModbusDeviceConfig.from_dict(
+        {
+            "name": name,
+            "protocol": "MODBUS",
+            "config": {
+                "transport": "tcp",
+                "host": host,
+                "port": port,
+                "slave_id": slave_id,
+                "timeout_ms": 1000,
+                "io_points": [],
+            },
+        }
+    )
+
+
+def _config(devices):
+    cfg = ModbusMasterConfig()
+    cfg.devices = devices
+    return cfg
+
+
+# --- Validation ----------------------------------------------------------
+
+def test_gateway_same_ip_different_slave_ids_is_valid():
+    """Multiple TCP devices on one IP:port with distinct slave IDs (a gateway)."""
+    cfg = _config([
+        _tcp_device("G1", slave_id=1),
+        _tcp_device("G2", slave_id=2),
+        _tcp_device("G3", slave_id=10),
+    ])
+    cfg.validate()  # must not raise
+
+
+def test_same_ip_same_slave_id_is_rejected():
+    """Same host:port AND slave_id is a true duplicate -> rejected."""
+    cfg = _config([_tcp_device("A", slave_id=5), _tcp_device("B", slave_id=5)])
+    with pytest.raises(ValueError, match="slave"):
+        cfg.validate()
+
+
+def test_different_ip_same_slave_id_is_valid():
+    """Different gateways may each expose the same slave ID."""
+    cfg = _config([
+        _tcp_device("A", host="10.0.0.1", slave_id=1),
+        _tcp_device("B", host="10.0.0.2", slave_id=1),
+    ])
+    cfg.validate()  # must not raise
+
+
+def test_same_ip_different_port_is_valid():
+    cfg = _config([
+        _tcp_device("A", port=502, slave_id=1),
+        _tcp_device("B", port=503, slave_id=1),
+    ])
+    cfg.validate()  # must not raise
+
+
+# --- Endpoint grouping ----------------------------------------------------
+
+def test_group_tcp_collapses_same_endpoint():
+    """Devices sharing host:port land in one group (one shared connection)."""
+    devs = [_tcp_device("G1", slave_id=1), _tcp_device("G2", slave_id=2)]
+    groups = group_tcp_devices_by_endpoint(devs)
+    assert list(groups.keys()) == ["192.168.1.50:502"]
+    info = groups["192.168.1.50:502"]
+    assert len(info["devices"]) == 2
+    assert info["config"] == {"host": "192.168.1.50", "port": 502, "timeout_ms": 1000}
+    assert sorted(d.slave_id for d in info["devices"]) == [1, 2]
+
+
+def test_group_tcp_separates_distinct_endpoints():
+    devs = [
+        _tcp_device("A", host="10.0.0.1", port=502),
+        _tcp_device("B", host="10.0.0.1", port=503),
+        _tcp_device("C", host="10.0.0.2", port=502),
+    ]
+    groups = group_tcp_devices_by_endpoint(devs)
+    assert len(groups) == 3
+
+
+def test_group_tcp_uses_minimum_timeout():
+    devs = [
+        _tcp_device("G1", slave_id=1),
+        ModbusDeviceConfig.from_dict({
+            "name": "G2", "protocol": "MODBUS",
+            "config": {"transport": "tcp", "host": "192.168.1.50", "port": 502,
+                       "slave_id": 2, "timeout_ms": 250, "io_points": []},
+        }),
+    ]
+    groups = group_tcp_devices_by_endpoint(devs)
+    assert groups["192.168.1.50:502"]["config"]["timeout_ms"] == 250


### PR DESCRIPTION
## Problem
Ethernet-to-Modbus-RTU gateways (TCP-to-RTU converters) aggregate several serial slaves under **one IP:port**, distinguished by slave/unit ID. The runtime rejected this:
- The Modbus-master config validator keyed TCP devices by `(host, port)` and threw `"Duplicate host:port combinations found for TCP devices"` — so you couldn't define two slaves on a gateway IP.
- (The slave ID itself already reaches the MBAP unit byte via `device_id=slave_id`; the blocker was validation + the lack of a shared gateway connection.)

## Fix (end-to-end)
1. **Validation** (`modbus_master_config_model.py`): TCP devices keyed by `(host, port, slave_id)`. Multiple devices may share a host:port as long as slave IDs differ; only true duplicates (same endpoint **and** slave_id) are rejected.
2. **Connection model** (`modbus_master_plugin.py`): TCP devices grouped by `(host, port)`. A lone device keeps the one-thread `ModbusSlaveDevice` path; multiple devices on one endpoint share a **single TCP connection** and are multiplexed by `slave_id` — mirroring how a gateway routes, and avoiding N sockets to a gateway that may accept only one. The RTU-only `ModbusRtuBusHandler` is generalized to a transport-agnostic `ModbusBusHandler` (its poll loop already was transport-independent); the RTU multi-drop path is unchanged (back-compat alias retained).

## Tests
`tests/pytest/modbus_master/test_modbus_gateway.py` (7, all pass): validation accepts same-IP/different-slave, rejects true duplicates, allows different-IP/same-slave and same-IP/different-port; endpoint grouping collapses shared endpoints, separates distinct ones, uses the minimum timeout. No new regressions (the 3 failing tests in `test_modbus_master_plugin.py` fail identically on `development` — a stale harness, unrelated).

## Pairs with editor
The editor already permits same-IP/different-slave-ID devices and exports `slave_id` per TCP device, so no editor change is required for this. (Separate, unrelated editor bug noted during investigation: RTU fields aren't persisted in `updateRemoteDeviceConfig` — not addressed here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)