### PR TITLE
fix(runtime): sync located globals from STruC++'s locatedGlobals[]

### DIFF
--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(plc_main
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/utils/utils.c
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/utils/watchdog.c
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/image_tables.cpp
+    ${CMAKE_SOURCE_DIR}/core/src/plc_app/located_globals.c
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/journal_buffer.c
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/debug_write_journal.cpp
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/plc_io_cycle.cpp

--- a/core/src/plc_app/image_tables.cpp
+++ b/core/src/plc_app/image_tables.cpp
@@ -13,6 +13,7 @@
 
 extern "C" {
 #include "include/iec_python.h"
+#include "located_globals.h"
 }
 
 // Layout-compatible mirror of the strucpp ABI. The runtime executable
@@ -58,9 +59,18 @@ IEC_BOOL  *bool_memory[BUFFER_SIZE][8];
 namespace {
     using GetLocatedVarsFn  = const strucpp::LocatedVar *(*)(void);
     using GetLocatedCountFn = uint32_t (*)(void);
+    // Located CONFIGURATION VAR_GLOBALs. strucpp emits these accessors beside
+    // the array in the generated configuration TU (not in our shim), so an older
+    // program simply does not export them -- see the OPTIONAL note in
+    // image_tables.h and the fallback in image_tables_bind_located_vars().
+    using GetLocatedGlobalsFn      = void *const *(*)(void);
+    using GetLocatedGlobalCountFn  = uint32_t (*)(void);
 
     GetLocatedVarsFn  ext_strucpp_get_located_vars      = nullptr;
     GetLocatedCountFn ext_strucpp_get_located_var_count = nullptr;
+
+    GetLocatedGlobalsFn     ext_strucpp_get_located_globals      = nullptr;
+    GetLocatedGlobalCountFn ext_strucpp_get_located_global_count = nullptr;
 }
 
 // ---------------------------------------------------------------------------
@@ -94,14 +104,23 @@ namespace {
     uint64_t       *g_located_snapshot = nullptr;
     uint32_t        g_located_count    = 0;
 
-    // Config-scope located slice: the tail of locatedVars[] that belongs to
-    // CONFIGURATION VAR_GLOBAL ... AT (strucpp emits program-local located vars
-    // first, then the shared globals). These are NOT covered by any program's
-    // located_range(), so the per-task copy-in/out never touches them; the
-    // dispatcher copies this slice at the quiescent frame boundary instead (see
-    // image_tables_copy_config_globals_in/out). [offset, offset+count).
-    uint32_t        g_config_located_offset = 0;
-    uint32_t        g_config_located_count  = 0;
+    // Indices of the locatedVars[] entries that are CONFIGURATION VAR_GLOBAL
+    // ... AT. No program's located_range() covers them, so the per-task
+    // copy-in/out never touches them; the dispatcher copies them at the
+    // quiescent frame boundary instead (image_tables_copy_config_globals_in/out).
+    //
+    // Built once at program load by joining locatedVars[].pointer against the
+    // .so's locatedGlobals[] on POINTER IDENTITY. strucpp states which storage
+    // belongs to a configuration global; we never infer it.
+    //
+    // This deliberately replaces an earlier "[offset, count) tail not covered by
+    // any program range" slice. That assumed strucpp emitted program-local
+    // entries before config globals; the real order is the reverse, so the
+    // computed count collapsed to zero as soon as any POU declared a located
+    // variable and every located global silently stopped being serviced. Do not
+    // reintroduce any rule based on an entry's position in the array.
+    uint32_t       *g_located_globals_idx = nullptr;
+    uint32_t        g_located_globals_n   = 0;
 
     int init_recursive_pi_mutex(pthread_mutex_t *m)
     {
@@ -215,6 +234,17 @@ extern "C" int symbols_init(PluginManager *pm)
     *(void **)&ext_strucpp_get_located_vars      = resolve(pm, "strucpp_get_located_vars",      true);
     *(void **)&ext_strucpp_get_located_var_count = resolve(pm, "strucpp_get_located_var_count", true);
 
+    /* Located CONFIGURATION VAR_GLOBALs — OPTIONAL. strucpp emits these
+     * accessors beside locatedGlobals[] in the generated configuration TU, so a
+     * program exported by an editor that predates them simply does not have the
+     * symbols. When absent the runtime cannot tell which located entries are
+     * config-scope, so it services none of them (the program still runs, and
+     * POU-local located I/O is unaffected) and warns once at load. */
+    *(void **)&ext_strucpp_get_located_globals =
+        resolve(pm, "strucpp_get_located_globals", false);
+    *(void **)&ext_strucpp_get_located_global_count =
+        resolve(pm, "strucpp_get_located_global_count", false);
+
     *(void **)&ext_strucpp_debug_array_count = resolve(pm, "strucpp_debug_array_count", true);
     *(void **)&ext_strucpp_debug_elem_count  = resolve(pm, "strucpp_debug_elem_count",  true);
     *(void **)&ext_strucpp_debug_size        = resolve(pm, "strucpp_debug_size",        true);
@@ -280,6 +310,14 @@ extern "C" int symbols_init(PluginManager *pm)
     return 0;
 }
 
+// Adapter letting located_globals.c read locatedVars[i].pointer without knowing
+// the strucpp LocatedVar layout (that mirror lives only in this TU).
+static const void *located_pointer_at(const void *located_vars, uint32_t index)
+{
+    const strucpp::LocatedVar *lv = (const strucpp::LocatedVar *)located_vars;
+    return lv[index].pointer;
+}
+
 void image_tables_bind_located_vars(void)
 {
     if (!ext_strucpp_get_located_vars || !ext_strucpp_get_located_var_count)
@@ -299,14 +337,53 @@ void image_tables_bind_located_vars(void)
     g_located_snapshot =
         (uint64_t *)calloc(lv_count ? lv_count : 1, sizeof(uint64_t));
 
-    // Determine the config-scope located slice = the entries not covered by any
-    // program's located_range(). strucpp lays out locatedVars[] as
-    // [program-local ... ][config globals ... ], so the covered part is the
-    // prefix [0, covered_end) and the config globals are the tail
-    // [covered_end, lv_count). Compute covered_end as the max end over every
-    // program's range (robust to a program declaring zero located vars).
-    uint32_t covered_end = 0;
-    if (g_config_ptr)
+    // Build the config-scope index list. Authority is the .so's
+    // locatedGlobals[]: strucpp records there the canonical storage pointer of
+    // every located CONFIGURATION VAR_GLOBAL — the same raw_ptr() value it writes
+    // into locatedVars[].pointer — so an entry is config-scope exactly when its
+    // pointer appears in that array. Pointer identity, no layout or ordering
+    // assumption, and distinct objects have distinct addresses so there are no
+    // false positives.
+    free(g_located_globals_idx);
+    g_located_globals_idx = nullptr;
+    g_located_globals_n   = 0;
+
+    if (!ext_strucpp_get_located_globals || !ext_strucpp_get_located_global_count)
+    {
+        // Program exported before strucpp emitted locatedGlobals[]. We cannot
+        // identify the config-scope entries, and we will not guess: service none
+        // of them. The program still runs and POU-local located I/O is
+        // unaffected — only located VAR_GLOBALs are inert.
+        log_warn("[image_tables] this program does not export locatedGlobals[] "
+                 "(built by an older editor/STruC++) — located CONFIGURATION "
+                 "VAR_GLOBALs (%%IX/%%QX/%%MX/%%MW ... AT on a global) will NOT "
+                 "be synced; re-export the project from a current OpenPLC Editor");
+        log_info("[image_tables] %u located var(s) via copy-in/out "
+                 "(%u program-local, 0 config-scope shared globals)",
+                 lv_count, lv_count);
+        return;
+    }
+
+    const strucpp::LocatedVar *lv = ext_strucpp_get_located_vars();
+    void *const *lg      = ext_strucpp_get_located_globals();
+    uint32_t     lg_count = ext_strucpp_get_located_global_count();
+
+    if (lv_count)
+    {
+        g_located_globals_idx = (uint32_t *)calloc(lv_count, sizeof(uint32_t));
+        if (!g_located_globals_idx)
+        {
+            log_error("[image_tables] out of memory building the config-located "
+                      "index — located configuration globals will NOT be synced");
+            return;
+        }
+    }
+
+    // Independent cross-check witness: which indices a task actually claims via
+    // located_range(). Used only to detect disagreement with the authoritative
+    // classification, never to derive it.
+    uint8_t *claimed = (uint8_t *)calloc(lv_count ? lv_count : 1, 1);
+    if (claimed && g_config_ptr)
     {
         strucpp::ResourceInstance *res = g_config_ptr->get_resources();
         size_t rc = g_config_ptr->get_resource_count();
@@ -319,18 +396,47 @@ void image_tables_bind_located_vars(void)
                 {
                     uint32_t off = 0, cnt = 0;
                     tk.programs[p]->located_range(&off, &cnt);
-                    if (cnt && off + cnt > covered_end) covered_end = off + cnt;
+                    for (uint32_t i = off; i < off + cnt && i < lv_count; ++i)
+                        claimed[i] = 1;
                 }
             }
         }
     }
-    if (covered_end > lv_count) covered_end = lv_count;
-    g_config_located_offset = covered_end;
-    g_config_located_count  = lv_count - covered_end;
+
+    uint32_t matched_globals = 0;
+    g_located_globals_n = located_globals_join_ex(lv_count, lv,
+                                                 located_pointer_at,
+                                                 lg, lg_count,
+                                                 g_located_globals_idx,
+                                                 &matched_globals);
+
+    // Every entry in locatedGlobals[] must correspond to some locatedVars[]
+    // entry; a shortfall means the two arrays disagree, i.e. a codegen bug.
+    if (matched_globals != lg_count)
+    {
+        log_error("[image_tables] only %u of %u locatedGlobals[] entries matched "
+                  "a located variable — generated code is inconsistent",
+                  matched_globals, lg_count);
+    }
+
+    // A config global that a task's located_range() also claims would be copied
+    // twice, by the dispatcher and by that task.
+    if (claimed)
+    {
+        for (uint32_t j = 0; j < g_located_globals_n; ++j)
+        {
+            uint32_t k = g_located_globals_idx[j];
+            if (k < lv_count && claimed[k])
+                log_error("[image_tables] locatedVars[%u] is a configuration "
+                          "global but a task's located_range() also claims it — "
+                          "double-serviced slot", k);
+        }
+    }
+    free(claimed);
 
     log_info("[image_tables] %u located var(s) via copy-in/out "
              "(%u program-local, %u config-scope shared globals)",
-             lv_count, covered_end, g_config_located_count);
+             lv_count, lv_count - g_located_globals_n, g_located_globals_n);
 }
 
 // ---------------------------------------------------------------------------
@@ -415,6 +521,49 @@ uint64_t threaded_image_read(const strucpp::LocatedVar &v)
     return 0;
 }
 
+// Copy a SINGLE located entry. Both the per-task range walk and the config-scope
+// index walk go through these, so the two callers can never drift apart in how an
+// entry is actually moved.
+void copy_in_one(const strucpp::LocatedVar *lv, uint32_t k)
+{
+    uint64_t v = threaded_image_read(lv[k]);
+    threaded_member_write(lv[k], v);
+    if (g_located_snapshot) g_located_snapshot[k] = v;
+}
+
+void copy_out_one(const strucpp::LocatedVar *lv, uint32_t k)
+{
+    const strucpp::LocatedVar &v = lv[k];
+    if (v.area == strucpp::LocatedArea::Input) return;  // %I is never committed
+    uint64_t cur = threaded_member_read(v);
+    if (g_located_snapshot && cur == g_located_snapshot[k]) return;  // unchanged
+    if (g_located_snapshot) g_located_snapshot[k] = cur;
+    uint16_t idx = v.byte_index;
+    bool out = (v.area == strucpp::LocatedArea::Output);
+    switch (v.size)
+    {
+    case strucpp::LocatedSize::Bit:
+        journal_write_bool(out ? JOURNAL_BOOL_OUTPUT : JOURNAL_BOOL_MEMORY,
+                           idx, v.bit_index, cur != 0);
+        break;
+    case strucpp::LocatedSize::Byte:
+        journal_write_byte(JOURNAL_BYTE_OUTPUT, idx, (uint8_t)cur);
+        break;
+    case strucpp::LocatedSize::Word:
+        journal_write_int(out ? JOURNAL_INT_OUTPUT : JOURNAL_INT_MEMORY,
+                          idx, (uint16_t)cur);
+        break;
+    case strucpp::LocatedSize::DWord:
+        journal_write_dint(out ? JOURNAL_DINT_OUTPUT : JOURNAL_DINT_MEMORY,
+                           idx, (uint32_t)cur);
+        break;
+    case strucpp::LocatedSize::LWord:
+        journal_write_lint(out ? JOURNAL_LINT_OUTPUT : JOURNAL_LINT_MEMORY,
+                           idx, cur);
+        break;
+    }
+}
+
 }  // namespace
 
 extern "C" void image_tables_threaded_copy_in(uint32_t offset, uint32_t count)
@@ -423,12 +572,7 @@ extern "C" void image_tables_threaded_copy_in(uint32_t offset, uint32_t count)
     const strucpp::LocatedVar *lv = ext_strucpp_get_located_vars();
     uint32_t end = offset + count;
     if (end > g_located_count) end = g_located_count;
-    for (uint32_t k = offset; k < end; ++k)
-    {
-        uint64_t v = threaded_image_read(lv[k]);
-        threaded_member_write(lv[k], v);
-        if (g_located_snapshot) g_located_snapshot[k] = v;
-    }
+    for (uint32_t k = offset; k < end; ++k) copy_in_one(lv, k);
 }
 
 extern "C" void image_tables_threaded_copy_out(uint32_t offset, uint32_t count)
@@ -437,61 +581,45 @@ extern "C" void image_tables_threaded_copy_out(uint32_t offset, uint32_t count)
     const strucpp::LocatedVar *lv = ext_strucpp_get_located_vars();
     uint32_t end = offset + count;
     if (end > g_located_count) end = g_located_count;
-    for (uint32_t k = offset; k < end; ++k)
-    {
-        const strucpp::LocatedVar &v = lv[k];
-        if (v.area == strucpp::LocatedArea::Input) continue;  // %I is never committed
-        uint64_t cur = threaded_member_read(v);
-        if (g_located_snapshot && cur == g_located_snapshot[k]) continue;  // unchanged
-        if (g_located_snapshot) g_located_snapshot[k] = cur;
-        uint16_t idx = v.byte_index;
-        bool out = (v.area == strucpp::LocatedArea::Output);
-        switch (v.size)
-        {
-        case strucpp::LocatedSize::Bit:
-            journal_write_bool(out ? JOURNAL_BOOL_OUTPUT : JOURNAL_BOOL_MEMORY,
-                               idx, v.bit_index, cur != 0);
-            break;
-        case strucpp::LocatedSize::Byte:
-            journal_write_byte(JOURNAL_BYTE_OUTPUT, idx, (uint8_t)cur);
-            break;
-        case strucpp::LocatedSize::Word:
-            journal_write_int(out ? JOURNAL_INT_OUTPUT : JOURNAL_INT_MEMORY,
-                              idx, (uint16_t)cur);
-            break;
-        case strucpp::LocatedSize::DWord:
-            journal_write_dint(out ? JOURNAL_DINT_OUTPUT : JOURNAL_DINT_MEMORY,
-                               idx, (uint32_t)cur);
-            break;
-        case strucpp::LocatedSize::LWord:
-            journal_write_lint(out ? JOURNAL_LINT_OUTPUT : JOURNAL_LINT_MEMORY,
-                               idx, cur);
-            break;
-        }
-    }
+    for (uint32_t k = offset; k < end; ++k) copy_out_one(lv, k);
 }
 
-// Config-scope located globals (CONFIGURATION VAR_GLOBAL ... AT). These are the
-// tail slice of locatedVars[] that no program's located_range() covers, so the
-// per-task copy-in/out never reaches them. The dispatcher calls these at the
-// quiescent frame boundary (g_tasks_running == 0) so there is no concurrent
-// task access to the shared canonical storage — the copy is safe WITHOUT the
-// per-global mutex (quiescence is the synchronization). copy_in primes the
-// canonical globals from the image (inputs get fresh hardware values); copy_out
-// journals changed output/memory globals back to the image (drained by the
-// dispatcher). No-ops when there are no located globals.
+// Config-scope located globals (CONFIGURATION VAR_GLOBAL ... AT). No program's
+// located_range() covers these, so the per-task copy-in/out never reaches them.
+// The dispatcher calls these at the quiescent frame boundary
+// (g_tasks_running == 0) so there is no concurrent task access to the shared
+// canonical storage — the copy is safe WITHOUT the per-global mutex (quiescence
+// is the synchronization). copy_in primes the canonical globals from the image
+// (inputs get fresh hardware values); copy_out journals changed output/memory
+// globals back to the image (drained by the dispatcher).
+//
+// The entries are an explicit index list built at load by
+// image_tables_bind_located_vars() from the .so's locatedGlobals[]; they are NOT
+// a contiguous slice, so these walk the list rather than calling the range-based
+// helpers above. No-ops when the program has no located globals, or when it
+// predates locatedGlobals[] (a warning is logged once at load).
 extern "C" void image_tables_copy_config_globals_in(void)
 {
-    if (g_config_located_count)
-        image_tables_threaded_copy_in(g_config_located_offset,
-                                      g_config_located_count);
+    if (!g_located_globals_n || !g_located_globals_idx) return;
+    if (!ext_strucpp_get_located_vars) return;
+    const strucpp::LocatedVar *lv = ext_strucpp_get_located_vars();
+    for (uint32_t j = 0; j < g_located_globals_n; ++j)
+    {
+        uint32_t k = g_located_globals_idx[j];
+        if (k < g_located_count) copy_in_one(lv, k);
+    }
 }
 
 extern "C" void image_tables_copy_config_globals_out(void)
 {
-    if (g_config_located_count)
-        image_tables_threaded_copy_out(g_config_located_offset,
-                                       g_config_located_count);
+    if (!g_located_globals_n || !g_located_globals_idx) return;
+    if (!ext_strucpp_get_located_vars) return;
+    const strucpp::LocatedVar *lv = ext_strucpp_get_located_vars();
+    for (uint32_t j = 0; j < g_located_globals_n; ++j)
+    {
+        uint32_t k = g_located_globals_idx[j];
+        if (k < g_located_count) copy_out_one(lv, k);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -545,8 +673,9 @@ void image_tables_clear_null_pointers(void)
     free(g_located_snapshot);
     g_located_snapshot = nullptr;
     g_located_count    = 0;
-    g_config_located_offset = 0;
-    g_config_located_count  = 0;
+    free(g_located_globals_idx);
+    g_located_globals_idx = nullptr;
+    g_located_globals_n   = 0;
 
     std::memset(bool_input,   0, sizeof(bool_input));
     std::memset(bool_output,  0, sizeof(bool_output));

--- a/core/src/plc_app/image_tables.h
+++ b/core/src/plc_app/image_tables.h
@@ -163,8 +163,16 @@ extern "C"
      *
      * Shared globals no longer use a runtime-owned mutex — each carries its own
      * std::mutex inside the .so (strucpp GlobalVar<V>), taken per access in
-     * run(). The config-scope helpers copy the shared-global tail slice at the
-     * dispatcher's quiescent frame boundary (see image_tables.cpp).
+     * run(). The config-scope helpers copy the located CONFIGURATION VAR_GLOBALs
+     * at the dispatcher's quiescent frame boundary. Those entries are identified
+     * at load by joining locatedVars[].pointer against the .so's locatedGlobals[]
+     * on pointer identity — NOT by their position in locatedVars[], and NOT as a
+     * contiguous slice (see image_tables.cpp).
+     *
+     * locatedGlobals[] is OPTIONAL: a program exported before STruC++ emitted it
+     * does not export the accessors, in which case located configuration globals
+     * are not synced at all (the program still runs, POU-local located I/O is
+     * unaffected) and a warning is logged once at load.
      * --------------------------------------------------------------------- */
     void image_tables_threaded_copy_in(uint32_t offset, uint32_t count);
     void image_tables_threaded_copy_out(uint32_t offset, uint32_t count);

--- a/core/src/plc_app/located_globals.c
+++ b/core/src/plc_app/located_globals.c
@@ -1,0 +1,62 @@
+/* -----------------------------------------------------------------------------
+ * located_globals.c — see located_globals.h for the rationale.
+ * -------------------------------------------------------------------------- */
+
+#include <stddef.h>
+
+#include "located_globals.h"
+
+uint32_t located_globals_join_ex(uint32_t lv_count,
+                                 const void *located_vars,
+                                 located_pointer_at_fn pointer_at,
+                                 const void *const *globals,
+                                 uint32_t globals_count,
+                                 uint32_t *out_idx,
+                                 uint32_t *out_matched)
+{
+    uint32_t n = 0;
+
+    if (out_matched) *out_matched = 0;
+    if (!pointer_at || !out_idx) return 0;
+    if (!globals || globals_count == 0) return 0;
+
+    for (uint32_t i = 0; i < lv_count; ++i)
+    {
+        const void *p = pointer_at(located_vars, i);
+        /* An unbound descriptor can't be matched, and must not be guessed at. */
+        if (p == NULL) continue;
+
+        for (uint32_t g = 0; g < globals_count; ++g)
+        {
+            if (globals[g] == p)
+            {
+                out_idx[n++] = i;
+                break;
+            }
+        }
+    }
+
+    /* Report how many locatedGlobals[] entries found a home, so the caller can
+     * detect the two generated arrays disagreeing. Counted separately because a
+     * single global could in principle be referenced by more than one located
+     * descriptor (aliasing), which would make the index count misleading. */
+    if (out_matched)
+    {
+        uint32_t matched = 0;
+        for (uint32_t g = 0; g < globals_count; ++g)
+        {
+            if (globals[g] == NULL) continue;
+            for (uint32_t i = 0; i < lv_count; ++i)
+            {
+                if (pointer_at(located_vars, i) == globals[g])
+                {
+                    ++matched;
+                    break;
+                }
+            }
+        }
+        *out_matched = matched;
+    }
+
+    return n;
+}

--- a/core/src/plc_app/located_globals.h
+++ b/core/src/plc_app/located_globals.h
@@ -1,0 +1,78 @@
+/* -----------------------------------------------------------------------------
+ * located_globals.h — resolve which locatedVars[] entries are CONFIGURATION
+ * VAR_GLOBAL ... AT, by joining against the .so's locatedGlobals[] array.
+ *
+ * Pure logic with no runtime dependencies, so it can be unit-tested directly
+ * (tests/test_located_globals.c).
+ *
+ * Why a join, and why this module exists at all:
+ *
+ * locatedVars[] mixes two ownership classes. POU-local `VAR ... AT` is serviced
+ * by the owning IEC task around run(); CONFIGURATION `VAR_GLOBAL ... AT` is
+ * owned by no task, so the dispatcher copies it at the quiescent frame boundary.
+ * The LocatedVar descriptors carry no scope, and the runtime cannot recover it
+ * from the configuration tree — globals are file-scope singletons that appear
+ * nowhere in ConfigurationInstance -> Resource -> Task -> Program.
+ *
+ * The runtime used to INFER the split from position, assuming the layout was
+ * [program-local ...][config globals ...] and treating the tail uncovered by any
+ * program's located_range() as the globals. strucpp actually emits config
+ * globals FIRST, so the program-local block is always the tail: one POU-local
+ * located variable made the computed count collapse to zero and every located
+ * global silently stopped being serviced (forum: "%MX locations now invalid").
+ *
+ * strucpp now states the answer. locatedGlobals[] holds the canonical storage
+ * pointer of each located VAR_GLOBAL — the same raw_ptr() value written into
+ * locatedVars[].pointer — so an entry is config-scope exactly when its pointer
+ * appears in that array. Pointer identity: no ordering rule, no layout
+ * assumption, and no false positives, since distinct objects have distinct
+ * addresses.
+ * -------------------------------------------------------------------------- */
+
+#ifndef OPENPLC_LOCATED_GLOBALS_H
+#define OPENPLC_LOCATED_GLOBALS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Pointer accessor for a located variable. Kept as a callback so this module
+ * needs no knowledge of the strucpp LocatedVar layout and stays unit-testable.
+ * Returns the entry's canonical storage pointer, or NULL when unbound. */
+typedef const void *(*located_pointer_at_fn)(const void *located_vars,
+                                             uint32_t index);
+
+/* -----------------------------------------------------------------------------
+ * Join locatedVars[] against locatedGlobals[] and collect the config-scope
+ * indices, ascending.
+ *
+ *   lv_count        number of locatedVars[] entries
+ *   located_vars    opaque handle passed back to pointer_at
+ *   pointer_at      accessor yielding locatedVars[i]'s storage pointer
+ *   globals         locatedGlobals[] — storage pointers of the located globals
+ *   globals_count   number of entries in globals
+ *   out_idx         receives the config-scope indices; room for lv_count
+ *   out_matched     optional; receives how many `globals` entries matched some
+ *                   located variable. A value below globals_count means the two
+ *                   generated arrays disagree, which the caller should report.
+ *
+ * Returns the number of indices written to out_idx.
+ *
+ * Entries with a NULL pointer are skipped: an unbound descriptor cannot be
+ * matched, and guessing a scope for it is exactly the failure this replaces.
+ * -------------------------------------------------------------------------- */
+uint32_t located_globals_join_ex(uint32_t lv_count,
+                                 const void *located_vars,
+                                 located_pointer_at_fn pointer_at,
+                                 const void *const *globals,
+                                 uint32_t globals_count,
+                                 uint32_t *out_idx,
+                                 uint32_t *out_matched);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OPENPLC_LOCATED_GLOBALS_H */

--- a/tests/test_located_globals.c
+++ b/tests/test_located_globals.c
@@ -1,0 +1,264 @@
+/*
+ * test_located_globals.c — unit tests for located_globals_join_ex(), which
+ * resolves which locatedVars[] entries are CONFIGURATION VAR_GLOBAL ... AT by
+ * joining against the .so's locatedGlobals[] on pointer identity.
+ *
+ * Why this exists: the runtime used to derive the config-scope set from POSITION,
+ * assuming strucpp emitted [program-local ...][config globals ...] and treating
+ * the tail uncovered by any program's located_range() as the globals. strucpp
+ * emits config globals FIRST, so the program-local block is always the tail:
+ * `covered_end` reached locatedVarsCount as soon as any POU declared a located
+ * variable, the count collapsed to 0, and EVERY located configuration global
+ * (%MX, %QX, %MW alike) silently stopped being synced. Reported on the forum as
+ * "%MX locations now invalid - Runtime v4".
+ *
+ * The behaviour locked here:
+ *   - the join follows pointer identity only, so the result is identical whether
+ *     globals come first, last, or interleaved (ordering_* cases);
+ *   - out_matched reports how many locatedGlobals[] entries found a located
+ *     variable, so the caller can detect the two generated arrays disagreeing;
+ *   - unbound (NULL) descriptors are skipped rather than guessed at;
+ *   - an absent/empty globals array yields zero config-scope entries, which is
+ *     the "older program" degradation path.
+ *
+ * Build (standalone, no runtime deps):
+ *   cc -std=c11 -Wall -Wextra -I core/src/plc_app \
+ *      tests/test_located_globals.c core/src/plc_app/located_globals.c \
+ *      -o /tmp/test_located_globals && /tmp/test_located_globals
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+
+#include "located_globals.h"
+
+static int g_failures = 0;
+
+#define CHECK(cond, msg, ...)                                                  \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            printf("  FAIL: " msg "\n", ##__VA_ARGS__);                        \
+            ++g_failures;                                                      \
+        }                                                                      \
+    } while (0)
+
+/* ---------------------------------------------------------------------------
+ * Stand-in for locatedVars[]: an array of storage pointers. Distinct dummy
+ * objects give distinct addresses, exactly as real IEC storage does.
+ * ------------------------------------------------------------------------- */
+#define MAX_VARS 8
+static char  g_storage[MAX_VARS];          /* distinct addresses */
+static const void *g_lv[MAX_VARS];         /* the "locatedVars[i].pointer" values */
+
+static const void *pointer_at(const void *handle, uint32_t index)
+{
+    const void *const *lv = (const void *const *)handle;
+    return lv[index];
+}
+
+/* Convenience: address of dummy storage slot n. */
+#define S(n) ((const void *)&g_storage[n])
+
+static void reset(void)
+{
+    for (uint32_t i = 0; i < MAX_VARS; ++i) g_lv[i] = NULL;
+}
+
+/* ---------------------------------------------------------------------------
+ * The regression: config globals FIRST, one program-local var last. Under the
+ * old positional rule this produced zero config entries.
+ * ------------------------------------------------------------------------- */
+static void test_globals_first(void)
+{
+    printf("test_globals_first (the reported regression)\n");
+    reset();
+    g_lv[0] = S(0);   /* GLOBALVAR  AT %MD0    — config global */
+    g_lv[1] = S(1);   /* GLOBALBOOL AT %MX0.0  — config global */
+    g_lv[2] = S(2);   /* HW_IN      AT %IX0.1  — program-local */
+    const void *globals[] = { S(0), S(1) };
+
+    uint32_t idx[3], matched = 0;
+    uint32_t n = located_globals_join_ex(3, g_lv, pointer_at, globals, 2,
+                                         idx, &matched);
+
+    CHECK(n == 2, "expected 2 config globals, got %u", n);
+    CHECK(idx[0] == 0 && idx[1] == 1, "expected [0,1], got [%u,%u]", idx[0], idx[1]);
+    CHECK(matched == 2, "expected 2 matched globals, got %u", matched);
+}
+
+/* ---------------------------------------------------------------------------
+ * Order independence — the property the old code lacked.
+ * ------------------------------------------------------------------------- */
+static void test_ordering_independence(void)
+{
+    printf("test_ordering_independence\n");
+
+    /* (a) globals last */
+    {
+        reset();
+        g_lv[0] = S(0);            /* program-local */
+        g_lv[1] = S(1);
+        g_lv[2] = S(2);
+        const void *globals[] = { S(1), S(2) };
+        uint32_t idx[3], matched = 0;
+        uint32_t n = located_globals_join_ex(3, g_lv, pointer_at, globals, 2,
+                                             idx, &matched);
+        CHECK(n == 2, "(globals last) expected 2, got %u", n);
+        CHECK(idx[0] == 1 && idx[1] == 2, "(globals last) got [%u,%u]", idx[0], idx[1]);
+    }
+
+    /* (b) interleaved */
+    {
+        reset();
+        for (uint32_t i = 0; i < 4; ++i) g_lv[i] = S(i);
+        const void *globals[] = { S(0), S(2) };
+        uint32_t idx[4], matched = 0;
+        uint32_t n = located_globals_join_ex(4, g_lv, pointer_at, globals, 2,
+                                             idx, &matched);
+        CHECK(n == 2, "(interleaved) expected 2, got %u", n);
+        CHECK(idx[0] == 0 && idx[1] == 2, "(interleaved) got [%u,%u]", idx[0], idx[1]);
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * Multi-program shape that also collapsed to zero under the old rule:
+ * 3 globals, then two programs with two located vars each.
+ * ------------------------------------------------------------------------- */
+static void test_multi_program(void)
+{
+    printf("test_multi_program\n");
+    reset();
+    for (uint32_t i = 0; i < 7; ++i) g_lv[i] = S(i);
+    const void *globals[] = { S(0), S(1), S(2) };
+
+    uint32_t idx[7], matched = 0;
+    uint32_t n = located_globals_join_ex(7, g_lv, pointer_at, globals, 3,
+                                         idx, &matched);
+    CHECK(n == 3, "expected 3 config globals, got %u", n);
+    CHECK(idx[0] == 0 && idx[1] == 1 && idx[2] == 2,
+          "expected [0,1,2], got [%u,%u,%u]", idx[0], idx[1], idx[2]);
+    CHECK(matched == 3, "expected 3 matched, got %u", matched);
+}
+
+/* ------------------------------------------------------------------------- */
+static void test_degradation_and_edges(void)
+{
+    printf("test_degradation_and_edges\n");
+
+    /* Older program: no globals array at all (accessors absent). The caller
+     * warns and services no globals; the join must simply report zero. */
+    {
+        reset();
+        for (uint32_t i = 0; i < 3; ++i) g_lv[i] = S(i);
+        uint32_t idx[3], matched = 99;
+        CHECK(located_globals_join_ex(3, g_lv, pointer_at, NULL, 0, idx, &matched) == 0,
+              "NULL globals array should yield 0");
+        CHECK(matched == 0, "matched should be 0 for a NULL globals array");
+    }
+
+    /* Present but empty: project genuinely has no located globals. Distinct from
+     * the case above at the caller (no warning), identical here. */
+    {
+        reset();
+        for (uint32_t i = 0; i < 3; ++i) g_lv[i] = S(i);
+        const void *globals[] = { NULL };
+        uint32_t idx[3], matched = 99;
+        CHECK(located_globals_join_ex(3, g_lv, pointer_at, globals, 0, idx, &matched) == 0,
+              "count 0 should yield 0");
+        CHECK(matched == 0, "matched should be 0 when count is 0");
+    }
+
+    /* No located variables at all, but globals declared — nothing to join. */
+    {
+        reset();
+        const void *globals[] = { S(0) };
+        uint32_t idx[1], matched = 99;
+        CHECK(located_globals_join_ex(0, g_lv, pointer_at, globals, 1, idx, &matched) == 0,
+              "no located vars should yield 0");
+        CHECK(matched == 0, "no located vars means no global can match");
+    }
+
+    /* Every located var is a global (no POU declares one) — the shape that
+     * happened to work under the old positional rule. */
+    {
+        reset();
+        g_lv[0] = S(0); g_lv[1] = S(1);
+        const void *globals[] = { S(0), S(1) };
+        uint32_t idx[2], matched = 0;
+        CHECK(located_globals_join_ex(2, g_lv, pointer_at, globals, 2, idx, &matched) == 2,
+              "all-globals should yield 2");
+    }
+
+    /* Defensive: NULL accessor / NULL output must not crash and must yield 0. */
+    {
+        reset();
+        const void *globals[] = { S(0) };
+        uint32_t idx[2];
+        CHECK(located_globals_join_ex(2, g_lv, NULL, globals, 1, idx, NULL) == 0,
+              "NULL pointer_at should yield 0");
+        CHECK(located_globals_join_ex(2, g_lv, pointer_at, globals, 1, NULL, NULL) == 0,
+              "NULL out_idx should yield 0");
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * Inconsistency detection: a locatedGlobals[] entry that matches no located
+ * variable means the two generated arrays disagree. The join must report it via
+ * out_matched rather than silently dropping it.
+ * ------------------------------------------------------------------------- */
+static void test_inconsistency_detected(void)
+{
+    printf("test_inconsistency_detected\n");
+    reset();
+    g_lv[0] = S(0);
+    g_lv[1] = S(1);
+    /* S(5) belongs to no located variable — codegen bug. */
+    const void *globals[] = { S(0), S(5) };
+
+    uint32_t idx[2], matched = 0;
+    uint32_t n = located_globals_join_ex(2, g_lv, pointer_at, globals, 2,
+                                         idx, &matched);
+    CHECK(n == 1, "expected 1 config global, got %u", n);
+    CHECK(idx[0] == 0, "expected index 0, got %u", idx[0]);
+    CHECK(matched == 1, "expected matched=1 (< count 2) to flag the mismatch, got %u",
+          matched);
+}
+
+/* ---------------------------------------------------------------------------
+ * Unbound descriptors: a located variable whose pointer was never populated
+ * (e.g. a program never instantiated) must be skipped, not guessed at.
+ * ------------------------------------------------------------------------- */
+static void test_unbound_skipped(void)
+{
+    printf("test_unbound_skipped\n");
+    reset();
+    g_lv[0] = S(0);
+    g_lv[1] = NULL;   /* never bound */
+    g_lv[2] = S(2);
+    const void *globals[] = { S(0), S(2) };
+
+    uint32_t idx[3], matched = 0;
+    uint32_t n = located_globals_join_ex(3, g_lv, pointer_at, globals, 2,
+                                         idx, &matched);
+    CHECK(n == 2, "expected 2 config globals, got %u", n);
+    CHECK(idx[0] == 0 && idx[1] == 2, "expected [0,2], got [%u,%u]", idx[0], idx[1]);
+}
+
+int main(void)
+{
+    printf("=== located_globals_join_ex unit tests ===\n");
+    test_globals_first();
+    test_ordering_independence();
+    test_multi_program();
+    test_degradation_and_edges();
+    test_inconsistency_detected();
+    test_unbound_skipped();
+
+    if (g_failures == 0)
+    {
+        printf("=== all tests passed ===\n");
+        return 0;
+    }
+    printf("=== %d check(s) FAILED ===\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## The bug

`image_tables_bind_located_vars()` derived the config-scope located set **positionally**: it assumed STruC++ emitted program-local entries before `CONFIGURATION VAR_GLOBAL ... AT` entries, and took the tail not covered by any program's `located_range()` as the globals.

STruC++ emits config globals **first**, so the program-local block is always the tail. `covered_end` therefore reached `locatedVarsCount` as soon as **any** POU declared a located variable, `g_config_located_count` collapsed to `0`, and `image_tables_copy_config_globals_in/out` became no-ops — every located configuration global silently stopped being synced. `%MX` coils written over Modbus never reached the program, and `%IX`/`%QX`/`%MW` globals stopped being read and committed.

Reported on the forum as *"%MX locations now invalid - Runtime v4"*: the reporter's `%MX` writes worked until he added one unrelated located variable to a POU, and downgrading to **v4.1.3** — which predates the threaded process-image model — fixed it.

**Affected versions:** v4.1.4–v4.1.7 never copied located config globals at all; v4.1.8–v4.1.9 worked only while zero POUs declared a located variable. Nothing was logged in either case.

## Why the runtime could not fix this alone

The scope is unrecoverable here: globals are file-scope `GlobalVar<V>` singletons that appear nowhere in the object graph reachable through `ConfigurationInstance → Resource → Task → Program`. STruC++ now states it instead, emitting `locatedGlobals[]` with the canonical storage pointer of every located `VAR_GLOBAL` — the same `raw_ptr()` value it writes into `locatedVars[].pointer`.

## What changed

Replace the inferred slice with an **explicit index list built once at program load**, by joining `locatedVars[].pointer` against `locatedGlobals[]` on **pointer identity**. No ordering rule, no layout assumption, and no false positives since distinct objects have distinct addresses.

The join lives in `located_globals.c` behind a pointer-accessor callback, so it carries no STruC++ layout knowledge and is unit-testable.

Two validations guard the result:
- **Join totality** — every `locatedGlobals[]` entry must match some located variable, otherwise the generated arrays disagree.
- The program-range coverage bitmap is retained purely as an **independent cross-check witness**: it can flag a config global a task also claims, but it never decides a scope.

## Backwards compatible in both directions

STruC++ emits the `extern "C"` accessors beside its own array, so nothing here references a symbol an older program lacks — important because `scripts/compile.sh` rebuilds the shim against each upload's generated header, where a shim-side reference would be a **compile** error.

The accessors are resolved with `required=false` (same pattern as `strucpp_debug_locate`). An older program resolves NULL, in which case located configuration globals are not synced and a warning naming the fix is logged once at load. The program still runs and POU-local located I/O is unaffected. An older runtime never looks the symbols up and is bit-for-bit unaffected.

## Verification

Installed on a Raspberry Pi via the full `sudo ./install.sh`, driven entirely through the REST API (`/api/login` → `/api/upload-file?clean=1` → `/api/compilation-status` → `/api/start-plc`) exactly as the editor does. Test program: two located config globals (`%MX0.0`, `%MD0`) plus one POU-local located var (`%QX0.0`) — the shape that triggers the bug.

**Fix active:**
```
[image_tables] 3 located var(s) via copy-in/out (1 program-local, 2 config-scope shared globals)

initial       %MD0 = 9876     %MX0.0 coil = 0
coil 8192 ON  %MD0 = 1234     %MX0.0 coil = 1
coil 8192 OFF %MD0 = 9876
```
Both copy-in and copy-out confirmed over real Modbus TCP.

**Older program (no `locatedGlobals[]`):**
```
[WARNING] [image_tables] this program does not export locatedGlobals[] (built by an
older editor/STruC++) — located CONFIGURATION VAR_GLOBALs will NOT be synced;
re-export the project from a current OpenPLC Editor
[image_tables] 3 located var(s) via copy-in/out (3 program-local, 0 config-scope shared globals)
```
It compiled, started, and kept running — the program-local `%QX0.0` heartbeat toggled while `%MD0` stayed inert.

`tests/test_located_globals.c` covers order-independence, the multi-program shape, the degradation paths, inconsistency detection and unbound descriptors.

## Note for release

The fix activates only for programs **re-exported** from an editor shipping STruC++ v0.6.2 — the generated code carries `locatedGlobals[]`. Updating the runtime alone leaves the warning above rather than the fix, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

### Related PRs — merge together

This fix spans four repos. All target `development`.

| Repo | PR | Contents |
|---|---|---|
| STruCpp | Autonomy-Logic/STruCpp#202 | emits `locatedGlobals[]` + accessors; tightens located-address validation |
| openplc-runtime | Autonomy-Logic/openplc-runtime#161 | consumes it via pointer-identity join |
| openplc-editor | Autonomy-Logic/openplc-editor#983 | pins STruC++ v0.6.2 |
| openplc-web | Autonomy-Logic/openplc-web#643 | pins STruC++ v0.6.2 (shared parity) |

**Ordering:** the runtime degrades gracefully against an older STruC++ (warns, skips located globals, program still runs), and an older runtime ignores the new symbols entirely — so merge order does not matter. But the fix only becomes active for a project **re-exported** from an editor shipping v0.6.2, so all four need to land before it reaches users.