### PR TITLE
fix(opcua): write REAL/LREAL values, not their bit pattern

### DIFF
--- a/core/src/drivers/plugins/python/opcua/opcua_utils.py
+++ b/core/src/drivers/plugins/python/opcua/opcua_utils.py
@@ -3,7 +3,6 @@
 import ctypes
 import os
 import sys
-import struct
 from typing import Any
 from asyncua import ua
 
@@ -140,24 +139,13 @@ def convert_value_for_opcua(datatype: str, value: Any) -> Any:
             clamped_value = max(0, min(18446744073709551615, int(value)))
             return ctypes.c_uint64(clamped_value).value
 
-        elif datatype.upper() in ["FLOAT", "REAL"]:
-            # Float/Real values are stored as integers in debug variables
-            # Convert back to float if it's an integer representation
-            if isinstance(value, int):
-                try:
-                    return struct.unpack('f', struct.pack('I', value))[0]
-                except struct.error:
-                    return float(value)
-            return float(value)
-
-        elif datatype.upper() == "LREAL":
-            # LREAL (64-bit float) values are stored as integers in debug variables
-            # Convert back to double if it's an integer representation
-            if isinstance(value, int):
-                try:
-                    return struct.unpack('d', struct.pack('Q', value))[0]
-                except struct.error:
-                    return float(value)
+        elif datatype.upper() in ["FLOAT", "REAL", "LREAL"]:
+            # debug_read_value casts the raw bytes to c_float / c_double, so
+            # what arrives here is the number itself, never its bit pattern.
+            # The MatIEC-era debug protocol did hand over raw integers, and the
+            # struct.unpack that decoded them outlived it -- on the STruC++
+            # debug surface it would turn an integer-valued REAL of 1 into
+            # 1.4e-45. Mirror of the write-side fix below.
             return float(value)
 
         elif datatype.upper() == "STRING":
@@ -312,25 +300,13 @@ def convert_value_for_plc(datatype: str, value: Any) -> Any:
             clamped_value = max(0, min(18446744073709551615, int(value)))
             return ctypes.c_uint64(clamped_value).value
 
-        elif datatype.upper() in ["FLOAT", "REAL"]:
-            # Convert float to int representation for storage
-            if isinstance(value, float):
-                try:
-                    return struct.unpack('I', struct.pack('f', value))[0]
-                except struct.error:
-                    return int(value)
-            else:
-                return int(float(value))
-
-        elif datatype.upper() == "LREAL":
-            # Convert double to int representation for storage (64-bit)
-            if isinstance(value, float):
-                try:
-                    return struct.unpack('Q', struct.pack('d', value))[0]
-                except struct.error:
-                    return int(value)
-            else:
-                return int(float(value))
+        elif datatype.upper() in ["FLOAT", "REAL", "LREAL"]:
+            # debug_write_value packs this through c_float / c_double, so hand
+            # it the number. Packing the bit pattern here -- correct back when
+            # the debug protocol exchanged raw integers -- meant a client
+            # writing 42.0 stored 1109917696.0 in the PLC (forum thread
+            # "Error changing values via OPC UA").
+            return float(value)
 
         elif datatype.upper() == "STRING":
             return str(value)
@@ -391,8 +367,11 @@ def convert_value_for_plc(datatype: str, value: Any) -> Any:
         log_warn(f"Failed to convert value {value} to {datatype}, using default: {e}")
         if datatype.upper() == "BOOL":
             return 0
-        elif datatype.upper() in ["FLOAT", "REAL"]:
-            return 0
+        elif datatype.upper() in ["FLOAT", "REAL", "LREAL"]:
+            # Float default, matching the c_float / c_double the write path
+            # encodes with -- an int default would be a (harmless, but
+            # misleading) type mismatch.
+            return 0.0
         elif datatype.upper() == "STRING":
             return ""
         elif datatype.upper() in TIME_DATATYPES:

--- a/tests/pytest/plugins/opcua/test_type_conversions.py
+++ b/tests/pytest/plugins/opcua/test_type_conversions.py
@@ -9,7 +9,6 @@ Tests the functions in opcua_utils.py:
 """
 
 import pytest
-import struct
 import sys
 from pathlib import Path
 
@@ -247,12 +246,16 @@ class TestConvertValueForOpcua:
         result = convert_value_for_opcua("FLOAT", 3.14159)
         assert abs(result - 3.14159) < 0.0001
 
-    def test_float_from_int_representation(self):
-        """Float stored as int representation should be unpacked."""
-        # Pack 3.14159 as int representation
-        int_repr = struct.unpack('I', struct.pack('f', 3.14159))[0]
-        result = convert_value_for_opcua("FLOAT", int_repr)
-        assert abs(result - 3.14159) < 0.0001
+    def test_float_from_int_is_the_number_not_a_bit_pattern(self):
+        """An int reaching a FLOAT node is that number, widened.
+
+        debug_read_value hands over a real float (c_float / c_double), so
+        there is no bit pattern to decode. The MatIEC-era code reinterpreted
+        ints through struct.unpack, which turned a REAL of 1 into 1.4e-45.
+        """
+        assert convert_value_for_opcua("FLOAT", 1) == 1.0
+        assert convert_value_for_opcua("FLOAT", -7) == -7.0
+        assert convert_value_for_opcua("FLOAT", 1109917696) == 1109917696.0
 
     def test_float_zero(self):
         """Zero float should work correctly."""
@@ -270,12 +273,16 @@ class TestConvertValueForOpcua:
         result = convert_value_for_opcua("REAL", 3.14159)
         assert abs(result - 3.14159) < 0.0001
 
-    def test_real_from_int_representation(self):
-        """REAL stored as int representation should be unpacked."""
-        # Pack 3.14159 as int representation
-        int_repr = struct.unpack('I', struct.pack('f', 3.14159))[0]
-        result = convert_value_for_opcua("REAL", int_repr)
-        assert abs(result - 3.14159) < 0.0001
+    def test_real_from_int_is_the_number_not_a_bit_pattern(self):
+        """Same contract as FLOAT, for both REAL and LREAL."""
+        assert convert_value_for_opcua("REAL", 1) == 1.0
+        assert convert_value_for_opcua("LREAL", 42) == 42.0
+
+    # LREAL conversions (IEC 61131-3 LREAL = 64-bit float)
+    def test_lreal_from_float(self):
+        """LREAL values should pass through as float."""
+        result = convert_value_for_opcua("LREAL", -273.15)
+        assert abs(result - (-273.15)) < 0.0001
 
     # STRING conversions
     def test_string_normal(self):
@@ -396,26 +403,40 @@ class TestConvertValueForPlc:
         assert convert_value_for_plc("LINT", 1000000000) == 1000000000
 
     # FLOAT conversions
-    def test_float_to_int_representation(self):
-        """Float should be packed to int representation for PLC storage."""
-        result = convert_value_for_plc("FLOAT", 3.14159)
-        # Verify by unpacking back
-        unpacked = struct.unpack('f', struct.pack('I', result))[0]
-        assert abs(unpacked - 3.14159) < 0.0001
+    def test_float_stays_a_float(self):
+        """Floats are handed over as numbers, not as their bit pattern.
+
+        debug_write_value encodes with c_float / c_double, so packing the bit
+        pattern here would store the pattern as the value.
+        """
+        assert convert_value_for_plc("FLOAT", 3.5) == 3.5
+        assert convert_value_for_plc("FLOAT", -273.15) == -273.15
 
     def test_float_zero(self):
-        """Zero float should pack correctly."""
-        result = convert_value_for_plc("FLOAT", 0.0)
-        unpacked = struct.unpack('f', struct.pack('I', result))[0]
-        assert unpacked == 0.0
+        """Zero float should stay zero."""
+        assert convert_value_for_plc("FLOAT", 0.0) == 0.0
+
+    def test_float_from_int_is_widened_not_reinterpreted(self):
+        """A client sending an int to a Float node means that number."""
+        assert convert_value_for_plc("FLOAT", 3) == 3.0
 
     # REAL conversions (IEC 61131-3 REAL = 32-bit float)
-    def test_real_to_int_representation(self):
-        """REAL should be packed to int representation for PLC storage."""
-        result = convert_value_for_plc("REAL", 3.14159)
-        # Verify by unpacking back
-        unpacked = struct.unpack('f', struct.pack('I', result))[0]
-        assert abs(unpacked - 3.14159) < 0.0001
+    def test_real_stays_a_float(self):
+        """REAL and LREAL follow the same contract as FLOAT."""
+        assert convert_value_for_plc("REAL", 3.5) == 3.5
+        assert convert_value_for_plc("LREAL", -273.15) == -273.15
+
+    def test_real_write_of_42_is_not_a_bit_pattern(self):
+        """Regression: forum thread "Error changing values via OPC UA".
+
+        A client writing 42 saw 1.109918e+09 on a REAL and
+        4.6311077918204232e+18 on an LREAL -- the IEEE-754 bit patterns of
+        42.0 stored as the value itself.
+        """
+        assert convert_value_for_plc("REAL", 42.0) == 42.0
+        assert convert_value_for_plc("REAL", 42.0) != 1109917696
+        assert convert_value_for_plc("LREAL", 42.0) == 42.0
+        assert convert_value_for_plc("LREAL", 42.0) != 4631107791820423168
 
     # STRING conversions
     def test_string_normal(self):
@@ -536,30 +557,19 @@ class TestRoundTripConversions:
             assert plc_val == val
 
     def test_float_roundtrip(self):
-        """FLOAT values should survive round-trip conversion (with float precision)."""
-        for val in [0.0, 3.14159, -273.15, 1000000.5]:
-            # First convert float to int representation (as stored in PLC)
-            int_repr = struct.unpack('I', struct.pack('f', val))[0]
-            # Convert to OPC-UA
-            opcua_val = convert_value_for_opcua("FLOAT", int_repr)
-            # Convert back to PLC
+        """FLOAT values should survive round-trip conversion."""
+        for val in [0.0, 3.14159, -273.15, 1000000.5, 42.0]:
+            opcua_val = convert_value_for_opcua("FLOAT", val)
             plc_val = convert_value_for_plc("FLOAT", opcua_val)
-            # Unpack and compare
-            result = struct.unpack('f', struct.pack('I', plc_val))[0]
-            assert abs(result - val) < 0.0001
+            assert abs(plc_val - val) < 0.0001
 
     def test_real_roundtrip(self):
-        """REAL values should survive round-trip conversion (same as FLOAT)."""
-        for val in [0.0, 3.14159, -273.15, 1000000.5]:
-            # First convert float to int representation (as stored in PLC)
-            int_repr = struct.unpack('I', struct.pack('f', val))[0]
-            # Convert to OPC-UA
-            opcua_val = convert_value_for_opcua("REAL", int_repr)
-            # Convert back to PLC
-            plc_val = convert_value_for_plc("REAL", opcua_val)
-            # Unpack and compare
-            result = struct.unpack('f', struct.pack('I', plc_val))[0]
-            assert abs(result - val) < 0.0001
+        """REAL and LREAL values should survive round-trip conversion."""
+        for datatype in ("REAL", "LREAL"):
+            for val in [0.0, 3.14159, -273.15, 1000000.5, 42.0]:
+                opcua_val = convert_value_for_opcua(datatype, val)
+                plc_val = convert_value_for_plc(datatype, opcua_val)
+                assert abs(plc_val - val) < 0.0001
 
     def test_string_roundtrip(self):
         """STRING values should survive round-trip conversion."""

--- a/tests/pytest/plugins/opcua/test_write_path.py
+++ b/tests/pytest/plugins/opcua/test_write_path.py
@@ -1,0 +1,155 @@
+"""
+Round-trip tests for the OPC-UA write path.
+
+A client write travels
+
+    client value
+      -> convert_value_for_plc()      (opcua_utils.py)
+      -> debug_write_value()          (opcua_memory.py, encodes with ctypes)
+      -> PLC memory
+
+and comes back through debug_read_value() -> convert_value_for_opcua().
+The two ends were tested in isolation but never as a pair, which is how a
+float could be packed into its integer bit pattern on the way in and read
+back as that pattern: a client writing 42 to a REAL stored 1109917696.0
+(forum thread "Error changing values via OPC UA").
+
+These tests drive the real functions against a fake `args` whose debug_read /
+debug_write keep the bytes in a dict, exactly like the runtime keeps them in
+PLC memory.
+"""
+
+import ctypes
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add plugin path for imports
+_plugin_dir = (
+    Path(__file__).parent.parent.parent.parent.parent
+    / "core"
+    / "src"
+    / "drivers"
+    / "plugins"
+    / "python"
+)
+sys.path.insert(0, str(_plugin_dir / "opcua"))
+
+from opcua_memory import STATUS_OK, debug_read_value, debug_write_value
+from opcua_utils import convert_value_for_opcua, convert_value_for_plc
+
+
+class FakePlcMemory:
+    """Stands in for the runtime's debug surface.
+
+    Stores whatever bytes debug_write hands over, keyed by (arr, elem), and
+    replays them on debug_read -- the same contract plc_main implements.
+    """
+
+    def __init__(self):
+        self.cells = {}
+
+    def debug_write(self, arr, elem, buf, size):
+        key = (
+            int(arr.value if hasattr(arr, "value") else arr),
+            int(elem.value if hasattr(elem, "value") else elem),
+        )
+        length = int(size.value if hasattr(size, "value") else size)
+        self.cells[key] = bytes(buf[i] for i in range(length))
+        return STATUS_OK
+
+    def debug_read(self, arr, elem, buf):
+        key = (
+            int(arr.value if hasattr(arr, "value") else arr),
+            int(elem.value if hasattr(elem, "value") else elem),
+        )
+        raw = self.cells.get(key)
+        if raw is None:
+            return 0
+        for i, byte in enumerate(raw):
+            buf[i] = byte
+        return len(raw)
+
+
+@pytest.fixture
+def plc():
+    return FakePlcMemory()
+
+
+def write_then_read(plc, datatype, client_value):
+    """Full client-write -> PLC -> client-read cycle for one variable."""
+    plc_value = convert_value_for_plc(datatype, client_value)
+    assert debug_write_value(plc, 0, 0, datatype, plc_value) is True
+    stored = debug_read_value(plc, 0, 0, datatype)
+    return convert_value_for_opcua(datatype, stored)
+
+
+class TestFloatingPointWrites:
+    """Regression: forum thread "Error changing values via OPC UA"."""
+
+    def test_real_write_of_42_round_trips(self, plc):
+        assert write_then_read(plc, "REAL", 42.0) == 42.0
+
+    def test_lreal_write_of_42_round_trips(self, plc):
+        assert write_then_read(plc, "LREAL", 42.0) == 42.0
+
+    def test_real_does_not_store_the_bit_pattern(self, plc):
+        """The exact failure mode: 42.0 stored as 1109917696.0."""
+        assert write_then_read(plc, "REAL", 42.0) != 1109917696.0
+
+    def test_lreal_does_not_store_the_bit_pattern(self, plc):
+        assert write_then_read(plc, "LREAL", 42.0) != 4.6311077918204232e18
+
+    @pytest.mark.parametrize("value", [0.0, 1.5, -273.15, 1000000.5])
+    def test_lreal_keeps_full_double_precision(self, plc, value):
+        assert write_then_read(plc, "LREAL", value) == value
+
+    @pytest.mark.parametrize("value", [0.0, 1.5, -273.0, 42.0])
+    def test_real_keeps_float32_representable_values(self, plc, value):
+        # Values chosen to be exact in float32, so the comparison is exact.
+        assert write_then_read(plc, "REAL", value) == value
+
+    def test_real_narrows_to_float32(self, plc):
+        """A REAL is 32-bit: the stored value is the float32 rounding of the
+        client's double, not the double itself."""
+        result = write_then_read(plc, "REAL", 3.14159)
+        assert result == pytest.approx(3.14159, abs=1e-6)
+
+    def test_int_written_to_a_float_node_is_the_number(self, plc):
+        """A client may send an integer variant to a Float node."""
+        assert write_then_read(plc, "REAL", 42) == 42.0
+
+
+class TestIntegerWritesStillWork:
+    """INT was never affected; guard against fixing floats by breaking ints."""
+
+    @pytest.mark.parametrize(
+        "datatype,value",
+        [
+            ("INT", 42),
+            ("INT", -32768),
+            ("INT", 32767),
+            ("DINT", -2147483648),
+            ("UINT", 65535),
+            ("LINT", 9223372036854775807),
+            ("BOOL", True),
+            ("BOOL", False),
+        ],
+    )
+    def test_integer_round_trip(self, plc, datatype, value):
+        result = write_then_read(plc, datatype, value)
+        expected = bool(value) if datatype == "BOOL" else value
+        assert result == expected
+
+
+class TestEncoding:
+    """The bytes that reach PLC memory are the IEC-typed encoding."""
+
+    def test_real_writes_four_bytes_of_float32(self, plc):
+        debug_write_value(plc, 0, 0, "REAL", convert_value_for_plc("REAL", 42.0))
+        assert plc.cells[(0, 0)] == bytes(ctypes.c_float(42.0))
+
+    def test_lreal_writes_eight_bytes_of_float64(self, plc):
+        debug_write_value(plc, 0, 0, "LREAL", convert_value_for_plc("LREAL", 42.0))
+        assert plc.cells[(0, 0)] == bytes(ctypes.c_double(42.0))


### PR DESCRIPTION
Fixes the forum report "Error changing values via OPC UA" · RTOP-<n>

## Problem

Writing a floating-point value from an OPC-UA client stored garbage in the PLC.
A user wrote 42 to INT, REAL and LREAL variables: INT was correct, REAL read
back 1.109918e+09 and LREAL 4.6311077918204232e+18. Reading worked, and forcing
the value from the IDE debugger worked -- only client writes were wrong.

Those numbers are the IEEE-754 bit pattern of 42.0 read as an integer
(float32 -> 1109917696, float64 -> 4631107791820423168). The reporter's own IDE
screenshot confirms the PLC really holds `1109917696.000000` in a REAL.

## Root cause

The client write path is a single conversion hop:

    client 42.0 -> convert_value_for_plc('REAL', 42.0) -> debug_write_value(...)

`convert_value_for_plc` packed the float into its integer bit pattern
(`struct.unpack('I', struct.pack('f', value))`) and `debug_write_value` then
encoded that integer with `ctypes.c_float` -- storing 1109917696.0.

That packing was correct under the MatIEC-era debug protocol, which exchanged
variables as raw integers. When the plugin moved onto the STruC++ debug surface,
reads and writes became typed floats (`c_float` / `c_double`), but these two
helpers kept the old contract -- their comments still asserted "Float/Real
values are stored as integers in debug variables". This is why the reporter
notes the previous runtime version did not have the issue.

**Not endianness** (the initial hypothesis): byte-swapping 42.0f yields
1.44e-41 (10306 as an integer), not the reported values; INT writes were
unaffected; and the reporter reproduced it on two x86_64 hosts (Docker on
Ubuntu 24.04 and a mini-pc on Debian 13), which answers the platform question
raised in the thread.

## Changes

`core/src/drivers/plugins/python/opcua/opcua_utils.py` (+19 / -40):

- `convert_value_for_plc`: FLOAT/REAL/LREAL merge into one branch returning
  `float(value)`. This is the fix.
- `convert_value_for_opcua`: same merge, dropping the mirrored assumption
  (`isinstance(value, int)` decoded through `struct.unpack`). No observable
  behaviour change -- `debug_read_value` always returns a float and node seed
  values are `0.0` -- but leaving the read side decoding integers while the
  write side stops producing them would re-open this bug.
- Float exception fallback returns `0.0` instead of int `0`; the now-unused
  `struct` import is gone.

## Testing

`tests/pytest/plugins/opcua/test_type_conversions.py` asserted the buggy
contract (packing/unpacking bit patterns) and had no LREAL write coverage at
all. Those tests were rewritten, plus a regression pinned to the reported
values (42.0 in, 42.0 out, explicitly not 1109917696 / 4.6311077918204232e+18).

New `tests/pytest/plugins/opcua/test_write_path.py` exercises the full cycle --
`convert_value_for_plc` -> `debug_write_value` -> memory -> `debug_read_value`
-> `convert_value_for_opcua` -- against a fake `args` that keeps the bytes in a
dict like `plc_main` does. Nothing tested that pair before, which is how the
mismatch survived. It covers REAL/LREAL round-trips, the REAL float32 rounding,
an integer variant sent to a Float node, the exact bytes reaching memory, and a
non-regression class for integers and BOOL.

- 27 new tests pass; the two files together run 119 green.
- The new tests fail against the pre-fix code (20 failures when run against a
  copy with the original `opcua_utils.py`), so they pin the behaviour.
- Whole OPC-UA test folder: 48 failed / 170 passed before, 48 failed / 197
  passed after -- the same pre-existing failures, none new. Those 48 come from a
  stale fixture (`opcua_datatype_test.json` has no `format_version`, and the
  runtime requires >= 2) plus rate-limit tests in `test_user_manager.py`; they
  reproduce on a clean checkout and deserve their own ticket.
- `ruff` reports nothing on the touched code (the two F401s in `opcua_utils.py`
  are pre-existing, in the import fallback). The pre-existing files were
  deliberately not reformatted -- they are not black-clean at HEAD and
  reformatting would bury the fix in noise.

Manual verification: write 42.0 to a REAL and an LREAL node from an OPC-UA
client (with an explicit Float / Double variant) and confirm 42 both on
read-back and in the IDE debug view; write to an INT to confirm no regression.
The plugin is pure Python -- nothing to recompile -- but replacing the file in a
running container does not reload the already-imported module: restart the
container first.

## Related findings (separate tickets)

- TIME reads carry the same stale contract: `debug_read_value` returns int64
  nanoseconds while `convert_value_for_opcua("TIME", int)` assumes milliseconds
  and passes the value through -- a 1e6 factor error towards the client.
- Integer writes still clamp out-of-range values (40000 into an INT becomes
  32767) instead of the two's-complement wrap C/IEC perform. That is the
  mechanism behind openplc-editor#619; it changes live-path behaviour, so it
  needs its own ticket.
- `DOPE-251`, listed as related prior work, does not cover this path: no commit
  in either repo references it, and the endianness fixes that do exist are
  unrelated (EtherCAT SDO encoding; the Modbus MD5 sentinel in the editor).
