### PR TITLE
fix(webserver): stop tagging compiler stderr as fatal

### DIFF
--- a/webserver/plcapp_management.py
+++ b/webserver/plcapp_management.py
@@ -531,7 +531,20 @@ def run_compile(runtime_manager: RuntimeManager, cwd: str = "core/generated", cl
         )
 
         threading.Thread(target=stream_output, args=(compile_proc.stdout, ""), daemon=True).start()
-        threading.Thread(target=stream_output, args=(compile_proc.stderr, "[ERROR] "), daemon=True).start()
+        # stderr is NOT evidence of failure: g++ writes warnings, notes, and the
+        # quoted-source / `^~~~` caret lines under them to stderr too, beside real
+        # errors. Tagging the stream "[ERROR] " made every warning fatal to the
+        # editor, which names the last error-level line as the reason a build
+        # failed — so a build that merely warned came back as `upload_rejected`
+        # with a bare caret line as its message.
+        #
+        # The exit code is the verdict, and it already gets one: wait_step logs
+        # "[ERROR] Build failed (exit=N)" below. These lines are diagnostics, so
+        # they go in at WARNING and the operator reads the severity g++ itself
+        # printed in the text. Deliberately NOT parsed for severity — g++ output
+        # is localised and tool-specific, and a parser that misreads it would
+        # relabel real errors, which is worse than under-labelling warnings.
+        threading.Thread(target=stream_output, args=(compile_proc.stderr, "[WARNING] "), daemon=True).start()
 
         # Block until compile finishes.
         compile_ok = wait_step(compile_proc, "Build")
@@ -563,7 +576,8 @@ def run_compile(runtime_manager: RuntimeManager, cwd: str = "core/generated", cl
         )
 
         threading.Thread(target=stream_output, args=(cleanup_proc.stdout, ""), daemon=True).start()
-        threading.Thread(target=stream_output, args=(cleanup_proc.stderr, "[ERROR] "), daemon=True).start()
+        # Same reasoning as the compile drainer above.
+        threading.Thread(target=stream_output, args=(cleanup_proc.stderr, "[WARNING] "), daemon=True).start()
 
         cleanup_ok = wait_step(cleanup_proc, "Cleanup")
 


### PR DESCRIPTION
The device half of the upload false-negative. Pairs with **openplc-editor #1029**; both ride the retain feature branch so they merge with it.

**Two lines of change** (plus 14 of comment explaining why):

```diff
-threading.Thread(target=stream_output, args=(compile_proc.stderr, "[ERROR] "), daemon=True).start()
+threading.Thread(target=stream_output, args=(compile_proc.stderr, "[WARNING] "), daemon=True).start()
```

- **Every g++ warning reached the editor as an error.** The drainer tagged all of stderr `"[ERROR] "`, and g++ puts warnings, notes, and the quoted-source / `^~~~` caret lines under them on stderr too, beside real errors.
- **So a successful build reported as a failure.** The editor names the *last* error-level line as the reason a build failed, which turned a completed upload into `upload_rejected` whose message was a bare caret line. On an SLM-RP4 it fires whenever the VPP plugin is actually compiled rather than served from ccache — which is why a warm re-upload looks fine and the one right after `install.sh` does not.
- **Severity was never this layer's verdict to make.** The exit code is, and it already gets one: `wait_step` logs `[ERROR] Build failed (exit=N)`, and the editor's poller logs `Compilation failed (exit code: N)` at error level on a `FAILED` status. Neither depends on how individual g++ lines were tagged, so a real failure is still reported as an error by the source that actually knows.

## Deliberately not parsed for severity

An earlier revision of this PR matched `file:line:col: warning:` and carried the level onto the caret lines beneath it. It was rejected in review as too fragile, and that was the right call: diagnostics are **localised**, every tool in the pipeline (clang, ld, cmake, ccache, arduino-cli) formats differently, and the failure mode runs the dangerous direction — a parser that misses a real error relabels it as a warning. Under-labelling a warning costs a log colour; mislabelling an error hides a broken build.

The tradeoff accepted here: a genuine compile error's text now appears in the console at warning level. The build still fails, and the summary line still says so at error level.

## Verification

Real captured failure, before:

```json
{"ok":false,"error":{"code":"upload_rejected","message":"|     ^~~~~~~~~~~~~~~~~~~~..."}}
```

Every remaining `[ERROR]` in the file was checked to be a verdict about a determinate outcome — exit≠0, invalid program file, refused conf, orchestrator crash — rather than a stream tag.

No test accompanies this: with the classifier gone there is no pure function left to unit-test, and exercising it properly means driving a whole build. The behaviour is covered by the fact that a warning-only build now reports success.

Refs NODE-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FNp61926UEggtmsQPj3A3