### PR TITLE
feat(retain): runtime v4 retain — .so marshalling, plugin store, cold reset

### DIFF
--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(plc_main
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/journal_buffer.c
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/debug_write_journal.cpp
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/plc_io_cycle.cpp
+    ${CMAKE_SOURCE_DIR}/core/src/plc_app/plc_retain.cpp
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/plc_state_manager.cpp
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/plc_switch.c
     ${CMAKE_SOURCE_DIR}/core/src/plc_app/plcapp_manager.c

--- a/core/src/drivers/plugin_driver.c
+++ b/core/src/drivers/plugin_driver.c
@@ -1446,6 +1446,14 @@ int native_plugin_get_symbols(plugin_instance_t *plugin)
     // get_stats is fully optional — plugins that don't publish statistics
     // simply don't export it. No warning.
 
+    // Retain store (NODE-94), fully optional. A plugin exporting both becomes
+    // a candidate for this device's retain store; see
+    // plugin_driver_find_retain_store. No warning when absent — most plugins
+    // have nothing to do with retention.
+    native_bundle->retain_save  = (plugin_retain_save_func_t)dlsym(handle, "retain_save");
+    native_bundle->retain_load  = (plugin_retain_load_func_t)dlsym(handle, "retain_load");
+    native_bundle->retain_clear = (plugin_retain_clear_func_t)dlsym(handle, "retain_clear");
+
     // Store the native bundle and handle in the plugin instance
     plugin->native_plugin = native_bundle;
 
@@ -1473,6 +1481,66 @@ void python_plugin_cycle(plugin_instance_t *plugin)
 // Call cycle_start for all active native plugins that have registered the hook
 // This should be called at the beginning of each PLC scan cycle, before PLC logic execution
 // Plugins opt-in by implementing cycle_start(); opt-out by not implementing it (NULL pointer)
+// ---------------------------------------------------------------------------
+// Retain store
+// ---------------------------------------------------------------------------
+
+static bool plugin_provides_retain_store(const plugin_instance_t *p)
+{
+    // BOTH halves required. A store that can save and not load is worse than
+    // none: it would accept values every scan and silently never give them
+    // back, which looks like working retention right up until the reboot that
+    // matters.
+    return p && p->native_plugin && p->native_plugin->retain_save && p->native_plugin->retain_load;
+}
+
+plugin_instance_t *plugin_driver_find_retain_store(plugin_driver_t *driver)
+{
+    if (!driver) return NULL;
+
+    plugin_instance_t *chosen = NULL;
+    for (int i = 0; i < driver->plugin_count; i++)
+    {
+        plugin_instance_t *p = &driver->plugins[i];
+        if (p->degraded || !plugin_provides_retain_store(p)) continue;
+
+        if (!chosen)
+        {
+            chosen = p;
+            continue;
+        }
+        // Two stores would both appear to work and disagree on the next boot,
+        // which is a worse failure than refusing the second. First wins, and
+        // the rest are named so the misconfiguration is visible.
+        log_warn("Retain: plugin '%s' also provides retain storage; ignoring it — "
+                 "'%s' was found first",
+                 p->config.name, chosen->config.name);
+    }
+    return chosen;
+}
+
+int plugin_driver_retain_save(plugin_instance_t *store, const uint8_t *blob, uint16_t len)
+{
+    if (!plugin_provides_retain_store(store)) return -1;
+    return store->native_plugin->retain_save(blob, len);
+}
+
+int plugin_driver_retain_load(plugin_instance_t *store, uint8_t *out, uint16_t cap, uint16_t *out_len)
+{
+    if (out_len) *out_len = 0;
+    if (!plugin_provides_retain_store(store)) return -1;
+    return store->native_plugin->retain_load(out, cap, out_len);
+}
+
+int plugin_driver_retain_clear(plugin_instance_t *store)
+{
+    // Optional third hook: a plugin without it cannot be cold-reset, and
+    // reporting that as failure would make the editor's post-upload clear look
+    // broken on every such device.
+    if (!store || !store->native_plugin || !store->native_plugin->retain_clear) return 0;
+    return store->native_plugin->retain_clear();
+}
+
 void plugin_driver_cycle_start(plugin_driver_t *driver)
 {
     if (!driver || driver->plugin_count == 0)

--- a/core/src/drivers/plugin_driver.h
+++ b/core/src/drivers/plugin_driver.h
@@ -33,6 +33,35 @@ typedef int (*plugin_execute_command_func_t)(const char *command_json, char *res
 // Return 0 on success; any other value means "skip me this cycle."
 typedef int (*plugin_get_stats_func_t)(char *out, size_t out_size);
 
+/* ---- Optional: retain-variable storage (NODE-94) -------------------------
+ *
+ * A plugin that owns retention hardware exports these two and becomes the
+ * device's retain store. Same names, same status meaning and the same contract
+ * text as baremetal's `openplc_retain.h`, so a vendor writes one shape twice
+ * rather than learning two interfaces for one job.
+ *
+ * The runtime MARSHALS and the plugin STORES: what arrives is an opaque blob,
+ * already validated on the way back in (magic, format, layout hash, crc32), so
+ * a backend needs no understanding of retained variables at all.
+ *
+ * `retain_save` is called ONCE PER SCAN CYCLE, unconditionally, from the
+ * dispatcher's quiescent window. The runtime does not diff and does not
+ * rate-limit — holding the bytes and flushing on a schedule the medium can
+ * sustain is the plugin's job, and the reason the call exists at that cadence
+ * is so a plugin that CAN write every cycle (FRAM, battery-backed SRAM) is free
+ * to. It MUST return promptly and MUST NOT block: this runs inside the scan,
+ * so time spent here is time the PLC is not scanning.
+ *
+ * Both must be exported for the plugin to be used as the store; a plugin
+ * exporting only one is ignored, since a store that can save and not load is
+ * worse than none. Return 0 on success, non-zero otherwise.
+ */
+typedef int (*plugin_retain_save_func_t)(const uint8_t *blob, uint16_t len);
+typedef int (*plugin_retain_load_func_t)(uint8_t *out, uint16_t cap, uint16_t *out_len);
+/* Optional third: discard the stored blob. A plugin without it simply cannot
+ * be cold-reset, and the editor's post-upload clear is a no-op for it. */
+typedef int (*plugin_retain_clear_func_t)(void);
+
 typedef struct
 {
     void *handle; // Handle to the loaded shared library
@@ -44,6 +73,10 @@ typedef struct
     plugin_cleanup_func_t cleanup;
     plugin_execute_command_func_t execute_command;
     plugin_get_stats_func_t get_stats;
+    /* Optional retain-store hooks; NULL unless the plugin exports them. */
+    plugin_retain_save_func_t  retain_save;
+    plugin_retain_load_func_t  retain_load;
+    plugin_retain_clear_func_t retain_clear;
 } plugin_funct_bundle_t;
 
 // Plugin instance structure
@@ -118,6 +151,20 @@ void plugin_driver_release_gil(void);
 // Plugins opt-in by implementing cycle_start/cycle_end; opt-out by not implementing them
 void plugin_driver_cycle_start(plugin_driver_t *driver);
 void plugin_driver_cycle_end(plugin_driver_t *driver);
+
+/* ---- Retain store ------------------------------------------------------- */
+
+/* The plugin acting as this device's retain store, or NULL.
+ *
+ * The FIRST plugin that exports both retain_save and retain_load wins, and any
+ * others are logged and ignored. Two plugins writing the same retained values
+ * to different places would both appear to work and disagree on the next boot,
+ * which is a far worse failure than refusing the second. */
+plugin_instance_t *plugin_driver_find_retain_store(plugin_driver_t *driver);
+
+int plugin_driver_retain_save(plugin_instance_t *store, const uint8_t *blob, uint16_t len);
+int plugin_driver_retain_load(plugin_instance_t *store, uint8_t *out, uint16_t cap, uint16_t *out_len);
+int plugin_driver_retain_clear(plugin_instance_t *store);
 
 // Route a command to a specific plugin by name (for async commands like scan)
 int plugin_driver_execute_command(plugin_driver_t *driver, const char *plugin_name,

--- a/core/src/plc_app/image_tables.cpp
+++ b/core/src/plc_app/image_tables.cpp
@@ -85,6 +85,12 @@ uint16_t (*ext_strucpp_debug_size)       (uint8_t, uint16_t)             = nullp
 uint8_t  (*ext_strucpp_debug_set)        (uint8_t, uint16_t, bool,
                                           const uint8_t *, uint16_t)     = nullptr;
 uint16_t (*ext_strucpp_debug_read)       (uint8_t, uint16_t, uint8_t *)  = nullptr;
+size_t   (*ext_strucpp_retain_blob_size)  (void)                       = nullptr;
+uint32_t (*ext_strucpp_retain_layout_hash)(void)                       = nullptr;
+size_t   (*ext_strucpp_retain_pack)       (uint8_t *, size_t)          = nullptr;
+uint8_t  (*ext_strucpp_retain_unpack)     (const uint8_t *, size_t,
+                                           uint8_t (*)(uint8_t, uint16_t,
+                                                       const uint8_t *, uint16_t)) = nullptr;
 uint8_t  (*ext_strucpp_debug_write)      (uint8_t, uint16_t,
                                           const uint8_t *, uint16_t)     = nullptr;
 int      (*ext_strucpp_debug_locate)     (uint8_t, uint16_t, uint8_t *,
@@ -251,6 +257,14 @@ extern "C" int symbols_init(PluginManager *pm)
     *(void **)&ext_strucpp_debug_set         = resolve(pm, "strucpp_debug_set",         true);
     *(void **)&ext_strucpp_debug_read        = resolve(pm, "strucpp_debug_read",        true);
     *(void **)&ext_strucpp_debug_write       = resolve(pm, "strucpp_debug_write",       true);
+
+    /* Optional: a program built by an older STruC++ has no retain exports, and
+     * the retain path then simply never runs. `required = false` so that is a
+     * quiet degradation rather than a failed load. */
+    *(void **)&ext_strucpp_retain_blob_size   = resolve(pm, "strucpp_retain_blob_size",   false);
+    *(void **)&ext_strucpp_retain_layout_hash = resolve(pm, "strucpp_retain_layout_hash", false);
+    *(void **)&ext_strucpp_retain_pack        = resolve(pm, "strucpp_retain_pack",        false);
+    *(void **)&ext_strucpp_retain_unpack      = resolve(pm, "strucpp_retain_unpack",      false);
     /* Optional: present only on .so's built with strucpp_capabilities bit 2.
      * When NULL the debug-write drain routes every leaf as a global write. */
     *(void **)&ext_strucpp_debug_locate      = resolve(pm, "strucpp_debug_locate",      false);

--- a/core/src/plc_app/image_tables.h
+++ b/core/src/plc_app/image_tables.h
@@ -83,6 +83,28 @@ extern "C"
                                                      const uint8_t *bytes,
                                                      uint16_t len);
 
+    /* ---- Retain marshalling (NODE-94) --------------------------------------
+     *
+     * The WALK lives inside the .so, not here: that is where the debug tables
+     * and handle_read/handle_write are, and re-implementing the blob format on
+     * this side would put two copies of one wire format in two repos.
+     *
+     * `unpack` takes a write CALLBACK because the runtime owns the write path.
+     * A retained variable may also be LOCATED (`VAR RETAIN x AT %MW10`), and
+     * poking such a leaf's IECVar is undone by the next copy-in from the
+     * process image — so the callback we hand over routes through
+     * runtime_external_write, which knows to send a located leaf through the
+     * image journal.
+     *
+     * Optional: a program built by an older STruC++ resolves these to NULL and
+     * the retain path simply never runs. */
+    extern size_t   (*ext_strucpp_retain_blob_size)  (void);
+    extern uint32_t (*ext_strucpp_retain_layout_hash)(void);
+    extern size_t   (*ext_strucpp_retain_pack)       (uint8_t *out, size_t cap);
+    extern uint8_t  (*ext_strucpp_retain_unpack)     (const uint8_t *blob, size_t len,
+                                                      uint8_t (*write_leaf)(uint8_t, uint16_t,
+                                                                            const uint8_t *, uint16_t));
+
     /* Located-variable classifier. Reports whether a debug (arr, elem) leaf is
      * a LOCATED variable and, if so, its image location (area / size /
      * byte_index / bit_index). Returns 1 + fills the out-params if located, 0

--- a/core/src/plc_app/plc_retain.cpp
+++ b/core/src/plc_app/plc_retain.cpp
@@ -1,0 +1,164 @@
+/**
+ * @file plc_retain.cpp
+ * @brief Retain-variable persistence — the runtime's half (NODE-94).
+ *
+ * See plc_retain.h for the split: the .so marshals, a plugin stores, and this
+ * file owns the buffer and the call sites.
+ */
+
+#include "plc_retain.h"
+
+#include <atomic>
+#include <cstring>
+#include <vector>
+
+extern "C" {
+#include "../drivers/plugin_driver.h"
+#include "utils/log.h"
+}
+
+#include "debug_write_journal.h"
+#include "image_tables.h"
+
+extern plugin_driver_t *plugin_driver;
+
+namespace {
+
+/**
+ * Cap on the blob this runtime will handle.
+ *
+ * Generous compared with baremetal's 512 bytes — there is no SRAM pressure
+ * here — but bounded on purpose: the buffer is read from the scan path, and an
+ * unbounded allocation driven by a program's declaration count is not
+ * something to discover on a running machine. A program needing more is
+ * refused at init with a message naming both numbers.
+ */
+constexpr size_t RETAIN_BUFFER_MAX = 64 * 1024;
+
+std::vector<uint8_t> g_buffer;
+std::atomic<bool>    g_active{false};
+
+/**
+ * Restore writes go through the runtime's external-write path, NOT straight to
+ * the IECVar.
+ *
+ * A retained variable may also be located (`VAR RETAIN x AT %MW10`). Poking
+ * such a leaf's storage directly is undone by the next copy-in from the process
+ * image, so the value would appear to restore and then silently revert on the
+ * first scan. `runtime_external_write` classifies the leaf and routes a located
+ * one through the image journal — the same path OPC-UA writes take.
+ *
+ * DBGW_OP_WRITE, never a force: restoring a retained value must not pin it. The
+ * program has to be able to move it on the very next scan, and an operator's
+ * force has to stay authoritative over whatever was stored.
+ */
+uint8_t retain_write_leaf(uint8_t arr, uint16_t elem, const uint8_t *bytes, uint16_t len)
+{
+    return runtime_external_write(arr, elem, (uint8_t)DBGW_OP_WRITE, bytes, len) == 0 ? 0x7E : 0x82;
+}
+
+/** The first plugin that exports both hooks wins; see plc_retain_init(). */
+plugin_instance_t *g_store = nullptr;
+
+}  // namespace
+
+void plc_retain_init(void)
+{
+    g_active.store(false);
+    g_store = nullptr;
+    g_buffer.clear();
+
+    if (!ext_strucpp_retain_blob_size || !ext_strucpp_retain_pack || !ext_strucpp_retain_unpack)
+    {
+        /* A program built by an older STruC++. Not an error — retain simply
+         * does not run, exactly as before these exports existed. */
+        return;
+    }
+
+    const size_t needed = ext_strucpp_retain_blob_size();
+    if (needed == 0) return; /* the program retains nothing */
+
+    if (needed > RETAIN_BUFFER_MAX)
+    {
+        log_error("Retain: program needs %zu bytes, this runtime handles at most %zu — "
+                  "retained variables will NOT be preserved",
+                  needed, RETAIN_BUFFER_MAX);
+        return;
+    }
+
+    g_store = plugin_driver_find_retain_store(plugin_driver);
+    if (!g_store)
+    {
+        /* Info, not a warning: a device with no retention plugin is a normal
+         * configuration, and the program still runs correctly — its retained
+         * variables just behave as NON_RETAIN. Said once so the operator can
+         * tell "not supported here" from "supported and broken". */
+        log_info("Retain: %zu bytes of retained variables, but no plugin provides storage — "
+                 "they will start at their initial values",
+                 needed);
+        return;
+    }
+
+    g_buffer.assign(needed, 0);
+    g_active.store(true);
+    log_info("Retain: %zu bytes across the program's retained variables (layout %08x)",
+             needed, ext_strucpp_retain_layout_hash ? ext_strucpp_retain_layout_hash() : 0u);
+}
+
+void plc_retain_load(void)
+{
+    if (!g_active.load() || !g_store) return;
+
+    uint16_t got = 0;
+    const int rc = plugin_driver_retain_load(g_store, g_buffer.data(),
+                                             (uint16_t)g_buffer.size(), &got);
+    if (rc != 0 || got == 0)
+    {
+        log_info("Retain: nothing stored yet — retained variables start at their initial values");
+        return;
+    }
+
+    const uint8_t res = ext_strucpp_retain_unpack(g_buffer.data(), got, retain_write_leaf);
+    if (res == 0)
+    {
+        log_info("Retain: restored %u bytes of retained variables", (unsigned)got);
+        return;
+    }
+
+    /* Deliberately explicit about WHICH check failed. "Retain refused" sends
+     * someone hunting; "the stored layout is from a different program" tells
+     * them it was the upload, and a crc failure tells them it was the store. */
+    static const char *why[] = {"ok",        "no data",       "bad magic",
+                                "bad format", "crc mismatch", "layout is from a different program",
+                                "truncated"};
+    log_warn("Retain: stored values refused (%s) — retained variables start at their initial values",
+             res < (sizeof(why) / sizeof(why[0])) ? why[res] : "unknown");
+}
+
+void plc_retain_save(void)
+{
+    if (!g_active.load() || !g_store) return;
+
+    const size_t n = ext_strucpp_retain_pack(g_buffer.data(), g_buffer.size());
+    if (n == 0) return;
+
+    /* Hand the bytes over and return. Whether this is committed to storage now,
+     * in five seconds, or on shutdown is the plugin's decision — it is the only
+     * layer that knows what its medium costs. */
+    plugin_driver_retain_save(g_store, g_buffer.data(), (uint16_t)n);
+}
+
+void plc_retain_clear(void)
+{
+    /* Not gated on g_active: a clear has to work even when this program has
+     * nothing retained, because what it is discarding belongs to the PREVIOUS
+     * program. That is the whole point of clearing on upload. */
+    plugin_instance_t *store = g_store ? g_store : plugin_driver_find_retain_store(plugin_driver);
+    if (!store) return;
+    plugin_driver_retain_clear(store);
+}
+
+bool plc_retain_active(void)
+{
+    return g_active.load();
+}

--- a/core/src/plc_app/plc_retain.h
+++ b/core/src/plc_app/plc_retain.h
@@ -1,0 +1,105 @@
+/**
+ * @file plc_retain.h
+ * @brief Retain-variable persistence — the runtime's half (NODE-94).
+ *
+ * The runtime MARSHALS and the platform STORES, exactly as on baremetal. The
+ * marshalling itself lives inside the loaded .so (STruC++'s `iec_retain.hpp`,
+ * reached through the `strucpp_retain_*` exports), because that is where the
+ * debug tables live and because one copy of a wire format is better than two.
+ * What this file owns is the buffer, the call sites, and the handover to a
+ * plugin.
+ *
+ * WHY A PLUGIN AND NOT A FILE HERE
+ * --------------------------------
+ * There is no default backend. Retention hardware is a property of the device,
+ * not of the runtime: an SLM-RP4 has a data partition, another box has FRAM or
+ * battery-backed SRAM, a third has nothing at all. A file-backed default in the
+ * runtime would look like support on every device and be wrong on most of them.
+ * With no plugin the calls are no-ops and retain degrades to NON_RETAIN, which
+ * is what the runtime did before this file existed.
+ *
+ * The plugin surface mirrors baremetal's `openplc_retain.h` name for name, so a
+ * vendor writing retain support reads one contract and implements the same
+ * shape twice.
+ *
+ * CADENCE IS NOT OURS TO DECIDE
+ * ----------------------------
+ * `plc_retain_save()` is called once per scan cycle, unconditionally. It does
+ * not diff, does not rate-limit and does not judge whether a value is worth
+ * keeping — the plugin holds the bytes and flushes on whatever schedule its
+ * medium can sustain. A driver over flash that wrote through on every call
+ * would consume its endurance budget in hours.
+ */
+
+#ifndef PLC_RETAIN_H
+#define PLC_RETAIN_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Decide once, after the program is loaded, whether retain can run.
+ *
+ * Checks that the .so exports the retain entry points (a program built by an
+ * older STruC++ does not), that the program retains anything at all, and that
+ * the blob fits the runtime's buffer. Logs what it found, once — including the
+ * layout hash, which is the thing to compare when a restore is unexpectedly
+ * refused.
+ *
+ * Call after symbols are resolved and `g_config` is constructed, before the
+ * first task is released.
+ */
+void plc_retain_init(void);
+
+/**
+ * @brief Restore retained values from the plugin's store.
+ *
+ * Safe and cheap when nothing is retained or no plugin provides storage. The
+ * blob is validated inside the .so (magic, format, layout hash, crc32) and a
+ * blob that fails leaves every variable at its declared initial value — a
+ * machine starting from its defaults is recoverable, one starting from
+ * plausible-looking garbage is not.
+ *
+ * Call once per program start, after plc_retain_init().
+ */
+void plc_retain_load(void);
+
+/**
+ * @brief Hand the current retained values to the plugin.
+ *
+ * Called ONCE PER SCAN CYCLE from the dispatcher's quiescent window, where
+ * `g_tasks_running == 0` and no worker is inside a body — the same guarantee
+ * `image_tables_copy_config_globals_out()` relies on. Reading the leaves
+ * anywhere else would race the task threads.
+ */
+void plc_retain_save(void);
+
+/**
+ * @brief Discard the stored blob, so the next start uses the declared
+ *        initialisers.
+ *
+ * Called on program upload (CODESYS clears retained memory on download, and a
+ * new program's values have no business surviving into it) and by the
+ * `RETAIN:CLEAR` socket command.
+ */
+void plc_retain_clear(void);
+
+/**
+ * @brief Whether retain is actually live: a program that retains something,
+ *        exports the entry points, and a plugin willing to store the bytes.
+ *
+ * Reported to the editor so "retain is configured but this device cannot do
+ * it" is visible rather than silent.
+ */
+bool plc_retain_active(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PLC_RETAIN_H */

--- a/core/src/plc_app/plc_state_manager.cpp
+++ b/core/src/plc_app/plc_state_manager.cpp
@@ -34,6 +34,7 @@ extern "C" {
 #include "debug_write_journal.h"
 #include "image_tables.h"
 #include "journal_buffer.h"
+#include "plc_retain.h"
 #include "plc_state_manager.h"
 #include "plcapp_manager.h"
 #include "scan_cycle_manager.h"
@@ -438,6 +439,15 @@ void *plc_cycle_thread(void *arg)
     image_tables_bind_located_vars();
     image_tables_fill_null_pointers();
     pthread_mutex_unlock(itm);
+
+    /* Retained variables. init() decides once whether retain can run here —
+     * does the .so export the entry points, does the program retain anything,
+     * is there a plugin willing to store it — and load() restores what was
+     * kept. Both must follow the located-variable binding above: a retained
+     * variable may also be located, and its image slot has to exist before
+     * anything writes through it. Both are no-ops when retain is not in play. */
+    plc_retain_init();
+    plc_retain_load();
 
     journal_buffer_ptrs_t journal_ptrs = {
         .bool_input   = bool_input,
@@ -965,6 +975,12 @@ void *plc_cycle_thread(void *arg)
                  * g_tasks_running == 0 so no worker is mid-scan, and we hold
                  * image_lock. Cheap no-op when nothing is queued. */
                 debug_write_journal_drain();
+                /* Retained values, once per scan. This window is the only place
+                 * they can be read safely: g_tasks_running == 0, so no worker is
+                 * inside a body mutating them — the same guarantee
+                 * copy_config_globals_out relies on. The plugin decides whether
+                 * these bytes are actually committed now; no-op with no store. */
+                plc_retain_save();
                 image_unlock();
                 if (plugin_driver) plugin_driver_cycle_end(plugin_driver);
                 cycle_end_pending = false;

--- a/core/src/plc_app/unix_socket.c
+++ b/core/src/plc_app/unix_socket.c
@@ -11,6 +11,7 @@
 
 #include "../drivers/plugin_driver.h"
 #include "debug_handler.h"
+#include "plc_retain.h"
 #include "plc_state_manager.h"
 #include "plc_switch.h"
 #include "scan_cycle_manager.h"
@@ -308,6 +309,19 @@ void handle_unix_socket_commands(const char *command, char *response, size_t res
     else if (strcmp(command, "SWITCH") == 0)
     {
         format_switch_response(response, response_size);
+    }
+    else if (strcmp(command, "RETAIN:CLEAR") == 0)
+    {
+        /* Discard stored retained values, so the next start uses the declared
+         * initialisers. The webserver calls this on program upload — CODESYS
+         * clears retained memory on download, and a new program's values have
+         * no business surviving into it.
+         *
+         * Answers OK even with no retain plugin: "discard what is stored" is
+         * satisfied by a device that stores nothing, and failing there would
+         * make every upload to such a device look broken. */
+        plc_retain_clear();
+        strncpy(response, "RETAIN:OK\n", response_size);
     }
     else if (strcmp(command, "START") == 0)
     {

--- a/core/strucpp_runtime/runtime_v4_entry.cpp
+++ b/core/strucpp_runtime/runtime_v4_entry.cpp
@@ -28,6 +28,7 @@
 #include "debug_dispatch.hpp"
 #include "iec_located.hpp"
 #include "iec_std_lib.hpp"   // ConfigurationInstance + __CURRENT_TIME_NS
+#include "iec_retain.hpp"    // retain blob format + pack/unpack
 #include "generated.hpp"
 
 #include <cstddef>
@@ -140,3 +141,62 @@ extern "C" void strucpp_set_current_time(int64_t ns) {
 // NOTE: the runtime no longer probes a "threaded ABI" capability symbol. It
 // compiles every .so itself with -DSTRUCPP_THREADED, so the threaded
 // process-image model is the only one; there is nothing to detect.
+
+// ---------------------------------------------------------------------------
+// Retain marshalling.
+//
+// The WALK lives here, inside the .so, because that is where the debug tables
+// and `handle_read` / `handle_write` are. The runtime is built once and loads
+// many .so files, so it cannot reach `strucpp::retain` by mangled name — and
+// re-implementing the blob format on its side would put two copies of a wire
+// format in two repos, which is exactly the drift `iec_retain.hpp` exists to
+// prevent.
+//
+// What the runtime DOES own is the write path, which is why unpack takes a
+// callback instead of using `handle_write` directly: a retained variable may
+// also be LOCATED (`VAR RETAIN x AT %MW10`), and poking such a leaf's IECVar
+// is undone by the next copy-in from the process image. The runtime passes a
+// thunk that routes through `runtime_external_write`, which knows to send a
+// located leaf through the image journal. Reads need no such care — a read
+// sees whatever the last copy-in left — so pack uses `handle_read` here.
+// ---------------------------------------------------------------------------
+
+static uint16_t retain_read_leaf(uint8_t arr, uint16_t elem, uint8_t* dest) {
+    return strucpp::debug::handle_read(arr, elem, dest);
+}
+
+static uint16_t retain_size_leaf(uint8_t arr, uint16_t elem) {
+    return strucpp::debug::handle_size(arr, elem);
+}
+
+/** Bytes a full blob occupies for this program; 0 when nothing is retained. */
+extern "C" size_t strucpp_retain_blob_size(void) {
+    return strucpp::retain::blob_size(retain_size_leaf);
+}
+
+/** Identity of the retain LAYOUT — reported so the runtime can log it. */
+extern "C" uint32_t strucpp_retain_layout_hash(void) {
+    return strucpp::debug::retain_layout_hash;
+}
+
+/** Serialise every retained leaf. Returns bytes written, 0 on failure. */
+extern "C" size_t strucpp_retain_pack(uint8_t* out, size_t cap) {
+    return strucpp::retain::pack(out, cap, retain_read_leaf, retain_size_leaf);
+}
+
+/**
+ * Restore every retained leaf, writing through the runtime's own callback.
+ *
+ * Returns `strucpp::retain::LoadResult` as a byte. Anything but 0 (Ok) means
+ * nothing was written and every variable keeps its declared initial value —
+ * the correct outcome for a corrupt or stale store, since a machine starting
+ * from its defaults is recoverable and one starting from plausible-looking
+ * garbage is not.
+ */
+extern "C" uint8_t strucpp_retain_unpack(
+    const uint8_t* blob,
+    size_t len,
+    uint8_t (*write_leaf)(uint8_t arr, uint16_t elem, const uint8_t* bytes, uint16_t n)) {
+    return static_cast<uint8_t>(
+        strucpp::retain::unpack(blob, len, write_leaf, retain_size_leaf));
+}

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -288,6 +288,16 @@ def handle_upload_file(data: dict) -> dict:
 
         safe_extract(zip_file, extract_dir, valid_files)
 
+        # A new program must not inherit the previous one's retained values.
+        # The layout hash already refuses a genuinely different set of retained
+        # variables, but two programs that happen to share a layout would
+        # otherwise silently inherit each other's state. CODESYS clears retained
+        # memory on download; this is the same rule.
+        try:
+            runtime_manager.clear_retained()
+        except Exception as e:  # never fail an upload over this
+            logger.warning("Could not clear retained values before upload: %s", e)
+
         # Verify the VPP package signature BEFORE anything from this upload is
         # copied into the runtime root and before any Makefile from it runs.
         #

--- a/webserver/runtimemanager.py
+++ b/webserver/runtimemanager.py
@@ -337,6 +337,29 @@ class RuntimeManager:
             logger.error("Failed to stop PLC runtime (unexpected): %s", e)
             return "STOP:ERROR\n"
 
+    def clear_retained(self):
+        """
+        Discard the runtime's stored retained values.
+
+        Called on program upload. CODESYS clears retained memory on download,
+        and a new program's retained values have no business surviving into it
+        — the layout hash would refuse a genuinely different program, but two
+        programs that happen to share a retain layout would otherwise inherit
+        each other's values silently.
+
+        Failure is logged and swallowed: the upload itself is what matters, and
+        a runtime that is not currently reachable has nothing stored that this
+        program will read anyway.
+        """
+        try:
+            return self.runtime_socket.send_and_receive("RETAIN:CLEAR\n")
+        except (OSError, socket.error) as e:
+            logger.warning("Could not clear retained values: %s", e)
+            return "RETAIN:ERROR\n"
+        except Exception as e:
+            logger.warning("Could not clear retained values (unexpected): %s", e)
+            return "RETAIN:ERROR\n"
+
     def status_plc(self):
         """
         Send STATUS command


### PR DESCRIPTION
Phase 4 of NODE-94 — the daemon half. Retained values round-trip through a plugin-supplied store, with the same contract baremetal got in openplc-editor #1031. Builds on strucpp #220.

## The walk lives inside the .so

`runtime_v4_entry.cpp` exports `strucpp_retain_pack` / `_unpack` / `_blob_size` / `_layout_hash`. The debug tables and `handle_read` are there, and the runtime is built once but loads many `.so` files — it cannot reach `strucpp::retain` by mangled name, and re-implementing the blob format on this side would put two copies of one wire format in two repos.

**`unpack` takes a write callback rather than using `handle_write` itself, and that is the important detail.** A retained variable may also be located (`VAR RETAIN x AT %MW10`); poking such a leaf's IECVar is undone by the next copy-in from the process image, so the value would appear to restore and then silently revert on the first scan. The runtime passes a thunk routing through `runtime_external_write`, which sends a located leaf through the image journal — the path OPC-UA writes already take. Reads need no such care, so pack uses `handle_read` directly.

## Call sites

| | |
|---|---|
| `plc_retain_save()` | Once per scan, from the dispatcher's **quiescent window** — `g_tasks_running == 0`, no worker inside a body. The same guarantee `copy_config_globals_out` relies on, and the only place the leaves can be read without racing the task threads. |
| `plc_retain_init()` / `_load()` | Start path, **after** located variables are bound — a retained variable may also be located, and its image slot has to exist before anything writes through it. |
| `RETAIN:CLEAR` | Unix socket, called by the webserver on upload. |

## No default backend, on purpose

Retention hardware is a property of the device, not of the runtime. A file-backed default here would look like support on every device and be wrong on most of them. With no plugin the calls are no-ops and retain degrades to `NON_RETAIN` — what the runtime did before.

**Both `retain_save` and `retain_load` are required to be a store.** One that can save and not load is worse than none: it accepts values every scan and silently never returns them, which looks like working retention right up to the reboot that matters. First plugin exporting both wins; others are named and ignored, because two stores would both appear to work and disagree on the next boot.

## Verified on the SLM-RP4 with a 5-second flush

A throwaway file-backed plugin, so the **asynchronous** half of the contract was actually exercised rather than assumed:

```
[INFO] Retain: 18 bytes across the program's retained variables (layout 0590d5d2)
```
matching the layout hash the editor wrote into `debug-map.json` for the same program.

The blob on disk decoded to exactly the designed header:
```
magic=0x4F52 format=1 layout=0x0590d5d2 payload_len=4 crc=0x06d16eda
payload: 73d40000 -> boots = 54387
```

The flush cadence, sampled while the runtime called `retain_save` at 50 Hz — **~250 API calls per disk write**, which is the decoupling the per-cycle cadence exists to allow:
```
t+ 2s mtime=18:36:29    t+ 6s mtime=18:36:34    t+10s mtime=18:36:39
t+ 4s mtime=18:36:29    t+ 8s mtime=18:36:34    t+12s mtime=18:36:39
```

And across a STOP/START, which unloads and reloads the `.so` and re-runs every declared initialiser:
```
before stop:  main:boots = 54478
[INFO] Retain: restored 18 bytes of retained variables
after start:  main:boots = 54568   <- restored, still counting
              main:counter = 4     <- not retained, correctly reset
```

## Found while deploying — NOT caused by this work

openplc-runtime's `development` branch requires `vpp_signature.json` (`webserver/vpp_package_signature.py`, which **does not exist on `main`**), and openplc-editor never emits it — `grep -rln vpp_signature src` in the editor returns nothing. So **any VPP-target upload from a current editor to a current-development runtime fails**:

> `this upload contains a VPP plugin but no usable package signature: vpp_signature.json is missing or unreadable`

It only surfaced because I moved the test device off `main`. I tested against the non-VPP `OpenPLC Runtime v4` target instead. Worth its own fix — the producing side appears to be unimplemented.

Refs NODE-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FNp61926UEggtmsQPj3A3