### PR TITLE
fix(retain): a disabled plugin is not a retain store [NODE-94 phase 5]

### DIFF
--- a/core/src/drivers/plugin_driver.c
+++ b/core/src/drivers/plugin_driver.c
@@ -1487,11 +1487,24 @@ void python_plugin_cycle(plugin_instance_t *plugin)
 
 static bool plugin_provides_retain_store(const plugin_instance_t *p)
 {
+    if (!p) return false;
+
+    // A DISABLED plugin is not a store, even though its symbols resolved.
+    //
+    // Loading resolves symbols for every plugin in plugins.conf; only starting
+    // is gated on `enabled`. Without this check a disabled plugin is still
+    // picked as the store, so retain reports itself active, hands it the blob
+    // every scan, and gets nothing back on the next boot — the values are
+    // simply gone, with a log line at start saying retain is configured and
+    // working. Found on hardware: an upload rewrote plugins.conf, disabled the
+    // storage plugin, and retain went on claiming to work.
+    if (!p->config.enabled) return false;
+
     // BOTH halves required. A store that can save and not load is worse than
     // none: it would accept values every scan and silently never give them
     // back, which looks like working retention right up until the reboot that
     // matters.
-    return p && p->native_plugin && p->native_plugin->retain_save && p->native_plugin->retain_load;
+    return p->native_plugin && p->native_plugin->retain_save && p->native_plugin->retain_load;
 }
 
 plugin_instance_t *plugin_driver_find_retain_store(plugin_driver_t *driver)


### PR DESCRIPTION
## A disabled plugin was still chosen as the retain store

Loading a plugin resolves its symbols; only *starting* it is gated on `enabled`. `plugin_driver_find_retain_store` checked neither.

So a disabled plugin whose `.so` had loaded was still selected. The result was retain that **reported itself working and was not**:

- init logged `Retain: N bytes across the program's retained variables (layout …)`
- the scan cycle handed the blob over every cycle
- the plugin — never started, its flush thread never running — kept none of it
- the values were simply gone on the next boot, with nothing in the log suggesting anything was wrong

## How it was found

By the most ordinary route. Uploading a project rewrote `plugins.conf` and disabled the storage plugin, and retain went on claiming to work. Anyone whose retain storage got switched off would have seen the same thing.

## After

The same configuration now logs the honest report — and the one that says what to do about it:

```
[INFO] Retain: 54 bytes of retained variables, but no plugin provides storage
       — they will start at their initial values
```

Verified on an SLM-RP4: with the store disabled, the message above; with it enabled, `Retain: 54 bytes across the program's retained variables (layout 618b1d38)` and a working restore across a program reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FNp61926UEggtmsQPj3A3
