### PR TITLE
fix(build): compile C++ libraries carried in a STruC++ upload

### DIFF
--- a/scripts/Makefile.strucpp
+++ b/scripts/Makefile.strucpp
@@ -5,11 +5,15 @@
 #
 #   - Per-file compilation rules let `make -j` saturate every core on
 #     the target platform (Pi 4 = 4×, x86 servers = 8–32×).
-#   - `wildcard $(GENERATED_DIR)/*.cpp` discovers however many .cpp
-#     files STruC++ split into. The codegen emits one TU per POU plus
-#     a shared configuration.cpp, so the file set varies per project
-#     — keeping the list out of this file means no Makefile churn
-#     when POUs are added or removed.
+#   - Sources are discovered by searching $(GENERATED_DIR), so the
+#     file set varies per project with no Makefile churn when POUs
+#     are added or removed. The codegen emits one TU per POU plus a
+#     shared configuration.cpp.
+#   - A project can also carry C++ libraries under
+#     $(GENERATED_DIR)/libraries/<name>/, each an ordinary library
+#     folder with its sources under src/. Every such src/ goes on the
+#     include path and its sources are compiled, so a block resolves
+#     `#include <Foo.h>` the same way it does on Arduino.
 #   - `ccache` is picked up automatically when present. Re-running a
 #     build where only one POU's body changed reuses every other .o
 #     from the cache, so incremental builds drop from minutes to a
@@ -73,9 +77,16 @@ CC     := $(if $(CCACHE),$(CCACHE) gcc,gcc)
 # preserve. Verified on an SLM-RP4: with the flag the .so leaves
 # /proc/<pid>/maps on every stop and re-maps fresh on every start; without it,
 # it never leaves -- one build's image stays pinned for the life of the process.
+# Libraries the editor materialised from enabled .stlib archives. Each is an
+# ordinary library folder, so `src/` is its include root; a folder without one
+# is taken as its own root.
+RESOURCE_LIB_DIRS := $(wildcard $(GENERATED_DIR)/libraries/*)
+RESOURCE_LIB_INC  := $(foreach d,$(RESOURCE_LIB_DIRS),$(if $(wildcard $d/src),$d/src,$d))
+
 CXXFLAGS := -std=c++17 -O1 -pipe -fPIC -Wall -DSTRUCPP_THREADED -fno-gnu-unique -MMD -MP \
             -Wno-unknown-pragmas -Wno-deprecated-declarations \
-            -I $(GENERATED_DIR) -I $(RUNTIME_INC) -I $(PYTHON_INC)
+            -I $(GENERATED_DIR) -I $(RUNTIME_INC) -I $(PYTHON_INC) \
+            $(addprefix -I ,$(RESOURCE_LIB_INC))
 
 # Python POU stubs (`{external …}` blocks emitted by the editor) call
 # `getpid()`, `create_shm_name()`, `python_block_loader()`. Those
@@ -85,10 +96,11 @@ CXXFLAGS := -std=c++17 -O1 -pipe -fPIC -Wall -DSTRUCPP_THREADED -fno-gnu-unique 
 # any Python POU pay nothing; the header is declarations only.
 GENERATED_CXXFLAGS := $(CXXFLAGS) -include iec_python.h
 
-# Discover every .cpp emitted into core/generated/. STruC++ splits
-# across configuration.cpp + one pou_<NAME>.cpp per POU, but this
-# Makefile doesn't care — wildcard adapts.
-GEN_CPP := $(wildcard $(GENERATED_DIR)/*.cpp)
+# Discover every .cpp under core/generated/, at any depth: the top-level TUs
+# STruC++ emitted, plus whatever each resource library carries below its own
+# root. `sort` makes the order reproducible across filesystems and drops any
+# duplicate.
+GEN_CPP := $(sort $(shell find $(GENERATED_DIR) -name '*.cpp'))
 GEN_OBJ := $(patsubst $(GENERATED_DIR)/%.cpp,$(BUILD_DIR)/%.o,$(GEN_CPP))
 
 SHIM_OBJ      := $(BUILD_DIR)/runtime_v4_entry.o
@@ -126,8 +138,12 @@ $(LIBPLC): $(GEN_OBJ) $(SHIM_OBJ) $(EXTRA_OBJS) | $(BUILD_DIR)
 
 # Generated TUs from the editor's upload. Force-include iec_python.h
 # so unqualified Python loader symbols in {external} blocks resolve.
+# `$(@D)` because a nested source maps to a nested object: a library source at
+# libraries/foo/src/transport/bar.cpp builds to
+# $(BUILD_DIR)/libraries/foo/src/transport/bar.o.
 $(BUILD_DIR)/%.o: $(GENERATED_DIR)/%.cpp | $(BUILD_DIR)
 	@echo "[INFO] Compiling $<..."
+	@mkdir -p $(@D)
 	$(CXX) $(GENERATED_CXXFLAGS) -c $< -o $@
 
 # Static runtime shim — lives in the runtime repo, not in the user


### PR DESCRIPTION
## Summary

An upload can carry ordinary C++ library folders under
`core/generated/libraries/<name>/`, but `Makefile.strucpp` could not build them:

- `GEN_CPP := $(wildcard $(GENERATED_DIR)/*.cpp)` globbed the top level only, so a
  library's sources were never compiled and the link failed on its symbols.
- Nothing put those libraries' headers on the include path, so a block's
  `#include <Foo.h>` did not resolve.
- The `%.o` pattern rule assumed a flat object tree, so a nested source had
  nowhere to build to.

Three changes:

- `RESOURCE_LIB_INC` derives an include root per library folder — its `src/` when
  it has one, the folder itself otherwise — and adds them with `addprefix -I`.
- Sources are discovered with `find`, so any depth is covered. Wrapped in `sort`
  for a reproducible order across filesystems.
- The pattern rule gained `mkdir -p $(@D)`, since
  `libraries/foo/src/transport/bar.cpp` now builds to
  `$(BUILD_DIR)/libraries/foo/src/transport/bar.o`.

An upload with no `libraries/` directory compiles exactly as before — `find`
returns the same set the old `wildcard` did, and `RESOURCE_LIB_INC` is empty.

This is the runtime half of an editor change that lets a `.stlib` ship the C/C++
sources its blocks compile against; the Arduino half needs nothing from here.

## Ticket

<!-- none — external contributor, no RTOP access -->

## How it was tested

Built `openplc-runtime` in Docker from this branch, uploaded a program using a
library that ships its protocol sources as resources, and confirmed the runtime
compiled and loaded it:

```
-I core/generated/libraries/SensorKit/src -I core/generated/libraries/SensorNet/src
Compiling core/generated/libraries/SensorNet/src/transport/HostUdpTransport.cpp...
  -o build/libraries/SensorNet/src/transport/HostUdpTransport.o
Build complete: build/new_libplc.so
PLC started.
```

Every part of the change is exercised: the per-library include roots, recursive
discovery, and `mkdir -p $(@D)` for the nested objects. The loaded `libplc_*.so`
carries the library's symbols as real objects in the link.

Also confirmed an upload carrying no `libraries/` directory builds unchanged.

## Checklist

- [ ] `bash scripts/run-pytest.sh` passes
- [ ] `pre-commit run` clean
- [x] Docs updated if behavior changed (README, CLAUDE.md, docs/)
- [ ] Follows `docs/pr-reviews/PR_REVIEW_CHECKLIST.md`