### PR TITLE
RTOP-273 Runtime: store and serve the source project snapshot

### DIFF
--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,0 +1,30 @@
+"""Test-wide bootstrap for modules that reach ``webserver.config``.
+
+``webserver.config`` has import-time side effects: it resolves a persistent
+data dir, creates it, writes a ``.env`` and reads secrets out of it. The
+platform defaults are absolute paths (``/run/runtime``, ``/var/lib/...``) that
+are read-only or absent on a developer machine, so importing anything that
+transitively pulls in ``webserver.config`` fails at collection time unless the
+overrides are in place first.
+
+Pointing them at a throwaway temp dir here -- in the ROOT conftest, which pytest
+imports before any test module -- means a test module does not have to know
+whether its import graph happens to reach config. It reaches it more often than
+it looks: the discovery responder, for one, reports the stored project name, so
+it now depends on the snapshot store, which depends on config.
+
+``setdefault`` throughout, so a suite that wants its own directories (see
+``restapi/conftest.py``) still gets them.
+"""
+
+import os
+import secrets
+import tempfile
+
+_TMP = tempfile.mkdtemp(prefix="openplc-tests-")
+os.environ.setdefault("OPENPLC_RUNTIME_DIR", os.path.join(_TMP, "run"))
+os.environ.setdefault("OPENPLC_PERSISTENT_DATA_DIR", os.path.join(_TMP, "data"))
+os.environ.setdefault("SQLALCHEMY_DATABASE_URI", f"sqlite:///{os.path.join(_TMP, 'test.db')}")
+os.environ.setdefault("JWT_SECRET_KEY", secrets.token_hex(32))
+os.environ.setdefault("PEPPER", secrets.token_hex(32))
+os.environ.setdefault("FLASK_ENV", "development")

--- a/tests/pytest/restapi/test_capabilities.py
+++ b/tests/pytest/restapi/test_capabilities.py
@@ -48,6 +48,7 @@ def test_capabilities_reports_runtime_version_and_editor_floor(client):
     assert body == {
         "runtimeVersion": RUNTIME_VERSION,
         "minEditorVersion": MIN_EDITOR_VERSION,
+        "projectSnapshot": True,
     }
 
 

--- a/tests/pytest/restapi/test_project_snapshot.py
+++ b/tests/pytest/restapi/test_project_snapshot.py
@@ -1,0 +1,301 @@
+"""Behavioural tests for the stored source-project snapshot.
+
+The device stores an optional archive of the project a program was built from
+so an admin can retrieve it later. Two properties carry the whole design and
+are what these tests pin down:
+
+  * **The stored project never outlives the program it belongs to.** An upload
+    clears it, a successful build promotes the new one, and anything else
+    leaves the device with none. A device that advertised a project it was not
+    running would be worse than one that advertises nothing.
+
+  * **The runtime never opens the archive.** Everything it reports about the
+    stored project comes from metadata sent alongside the bytes, so these tests
+    deliberately stage archives that are not valid ZIPs at all.
+
+Retrieval is admin-only, and that role check is the *whole* of the access
+control -- the archive is not encrypted on disk -- so the refusal paths matter
+as much as the happy path.
+"""
+
+import base64
+import json
+
+import pytest
+from conftest import auth, create_user, token_for
+
+from webserver import project_snapshot
+
+
+@pytest.fixture(autouse=True)
+def clean_snapshot_store():
+    """No test may see another's stored project."""
+    project_snapshot.clear()
+    yield
+    project_snapshot.clear()
+
+
+def _metadata(**overrides):
+    record = {
+        "formatVersion": 1,
+        "projectName": "Traffic Light",
+        "editorVersion": "4.2.0",
+        "uploadedBy": "admin",
+        "timestamp": "2026-08-31T12:00:00Z",
+        "libraries": [{"name": "Motion", "version": "1.2.0", "hash": "abc123"}],
+    }
+    record.update(overrides)
+    return project_snapshot.normalize_metadata(record)
+
+
+def _store(blob=b"not-a-real-zip-on-purpose", **overrides):
+    """Stage and promote, i.e. the state after a successful build."""
+    project_snapshot.stage(blob, _metadata(**overrides))
+    assert project_snapshot.promote() is True
+
+
+# --- the stage / promote / discard cycle ---------------------------------
+
+
+def test_nothing_is_stored_on_a_fresh_device():
+    assert project_snapshot.has_snapshot() is False
+    assert project_snapshot.read_metadata() is None
+    assert project_snapshot.read_blob() is None
+
+
+def test_a_staged_snapshot_is_not_yet_readable():
+    # Until the build succeeds the device has no business claiming a project:
+    # the program it would describe does not exist yet.
+    project_snapshot.stage(b"payload", _metadata())
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_promote_makes_the_staged_snapshot_the_stored_one():
+    project_snapshot.stage(b"payload", _metadata())
+    assert project_snapshot.promote() is True
+    assert project_snapshot.read_blob() == b"payload"
+    assert project_snapshot.read_metadata()["projectName"] == "Traffic Light"
+
+
+def test_discard_leaves_the_device_with_nothing():
+    # The failed-build path. compile-clean.sh has already removed the program's
+    # .so by this point, so "no program, no stored project" is the honest state.
+    project_snapshot.stage(b"payload", _metadata())
+    project_snapshot.discard_staged()
+    assert project_snapshot.promote() is False
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_promote_without_anything_staged_is_a_no_op():
+    # An upload that sent no snapshot still reaches promote() when its build
+    # succeeds. It must not resurrect anything.
+    assert project_snapshot.promote() is False
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_clear_then_no_stage_erases_the_previous_project():
+    # This is exactly what an upload from an older editor does, and it is the
+    # point: the device stops advertising a project it is no longer running.
+    _store()
+    project_snapshot.clear()
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_a_second_upload_replaces_the_first():
+    _store(b"first", projectName="First")
+    project_snapshot.clear()
+    project_snapshot.stage(b"second", _metadata(projectName="Second"))
+    project_snapshot.promote()
+    assert project_snapshot.read_blob() == b"second"
+    assert project_snapshot.read_metadata()["projectName"] == "Second"
+
+
+def test_a_failed_build_after_a_successful_one_leaves_nothing():
+    # The dangerous middle state: an old snapshot must not survive an upload
+    # whose build failed, because the old PROGRAM did not survive it either.
+    _store(b"first", projectName="First")
+    project_snapshot.clear()
+    project_snapshot.stage(b"second", _metadata(projectName="Second"))
+    project_snapshot.discard_staged()
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_an_oversized_snapshot_is_refused():
+    oversized = b"x" * (project_snapshot.MAX_SNAPSHOT_BYTES + 1)
+    with pytest.raises(project_snapshot.SnapshotError):
+        project_snapshot.stage(oversized, _metadata())
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_metadata_without_its_blob_describes_nothing():
+    # Defence against a half-written store: metadata alone is not a snapshot,
+    # because there is nothing to hand back.
+    _store()
+    project_snapshot._PROMOTED_BLOB.unlink()
+    assert project_snapshot.read_metadata() is None
+    assert project_snapshot.has_snapshot() is False
+
+
+# --- metadata normalisation ----------------------------------------------
+
+
+def test_metadata_requires_a_project_name():
+    with pytest.raises(project_snapshot.SnapshotError):
+        project_snapshot.normalize_metadata({"formatVersion": 1, "projectName": "  "})
+
+
+def test_metadata_requires_a_format_version():
+    with pytest.raises(project_snapshot.SnapshotError):
+        project_snapshot.normalize_metadata({"projectName": "P"})
+
+
+def test_metadata_rejects_a_non_object():
+    with pytest.raises(project_snapshot.SnapshotError):
+        project_snapshot.normalize_metadata(["not", "an", "object"])
+
+
+def test_unknown_metadata_keys_are_dropped():
+    # The device echoes this record to other clients, so the shape is the
+    # device's, not the uploader's.
+    record = project_snapshot.normalize_metadata(
+        {"formatVersion": 1, "projectName": "P", "somethingElse": "ignored"}
+    )
+    assert "somethingElse" not in record
+
+
+def test_control_characters_are_stripped_from_metadata_strings():
+    # These values land in a JSON discovery reply and in client UI; a newline in
+    # a project name should not be able to reshape either.
+    record = project_snapshot.normalize_metadata(
+        {"formatVersion": 1, "projectName": "Line\nBreak\tProject"}
+    )
+    assert "\n" not in record["projectName"]
+    assert "\t" not in record["projectName"]
+
+
+def test_malformed_library_entries_are_dropped_not_fatal():
+    record = project_snapshot.normalize_metadata(
+        {
+            "formatVersion": 1,
+            "projectName": "P",
+            "libraries": ["not-an-object", {"version": "1.0"}, {"name": "Real"}],
+        }
+    )
+    assert [lib["name"] for lib in record["libraries"]] == ["Real"]
+
+
+# --- discovery advertisement ---------------------------------------------
+
+
+def test_discovery_advertises_nothing_when_no_project_is_stored():
+    # Absence of the keys is how a client tells there is nothing to retrieve;
+    # there is deliberately no separate boolean.
+    assert project_snapshot.advertised_fields() == {}
+
+
+def test_discovery_advertises_only_name_and_timestamp():
+    _store()
+    fields = project_snapshot.advertised_fields()
+    assert fields == {
+        "project_name": "Traffic Light",
+        "project_timestamp": "2026-08-31T12:00:00Z",
+    }
+
+
+# --- GET /api/project-snapshot/info --------------------------------------
+
+
+def test_info_requires_authentication(client):
+    assert client.get("/api/project-snapshot/info").status_code == 401
+
+
+def test_info_reports_absence_on_a_fresh_device(client, admin_token):
+    body = client.get("/api/project-snapshot/info", headers=auth(admin_token)).get_json()
+    assert body == {"present": False}
+
+
+def test_info_reports_the_stored_project(client, admin_token):
+    _store(b"payload")
+    body = client.get("/api/project-snapshot/info", headers=auth(admin_token)).get_json()
+    assert body["present"] is True
+    assert body["projectName"] == "Traffic Light"
+    assert body["editorVersion"] == "4.2.0"
+    assert body["uploadedBy"] == "admin"
+    assert body["sizeBytes"] == len(b"payload")
+    assert body["libraries"][0]["name"] == "Motion"
+
+
+def test_info_is_open_to_non_admins(client, admin_token):
+    # Deciding whether to OFFER retrieval is not privileged; retrieving is.
+    _store()
+    create_user(client, "operator", "operator-pass", token=admin_token, role="user")
+    operator = token_for(client, "operator", "operator-pass")
+    resp = client.get("/api/project-snapshot/info", headers=auth(operator))
+    assert resp.status_code == 200
+    assert resp.get_json()["present"] is True
+
+
+# --- GET /api/project-snapshot -------------------------------------------
+
+
+def test_retrieval_requires_authentication(client):
+    assert client.get("/api/project-snapshot").status_code == 401
+
+
+def test_retrieval_is_refused_to_non_admins(client, admin_token):
+    # The stored project is not encrypted on the device, so this role check is
+    # the entire access control. It is not a second layer behind one.
+    _store()
+    create_user(client, "operator", "operator-pass", token=admin_token, role="user")
+    operator = token_for(client, "operator", "operator-pass")
+    assert client.get("/api/project-snapshot", headers=auth(operator)).status_code == 403
+
+
+def test_retrieval_returns_the_stored_archive_verbatim(client, admin_token):
+    blob = b"PK\x03\x04 pretend archive \x00\xff"
+    _store(blob)
+    body = client.get("/api/project-snapshot", headers=auth(admin_token)).get_json()
+    assert base64.b64decode(body["contentBase64"]) == blob
+    assert body["projectName"] == "Traffic Light"
+    assert body["filename"] == "project.zip"
+
+
+def test_retrieval_404s_when_nothing_is_stored(client, admin_token):
+    assert client.get("/api/project-snapshot", headers=auth(admin_token)).status_code == 404
+
+
+def test_retrieval_404s_while_a_snapshot_is_only_staged(client, admin_token):
+    # Mid-build: the program is not in place yet, so neither is the project.
+    project_snapshot.stage(b"payload", _metadata())
+    assert client.get("/api/project-snapshot", headers=auth(admin_token)).status_code == 404
+
+
+def test_the_runtime_never_parses_the_archive(client, admin_token):
+    # A blob that is definitively not a ZIP round-trips untouched. If this ever
+    # fails, something started inspecting the archive and the format is no
+    # longer free to change without touching the device.
+    blob = b"\x00\x01\x02 definitely not a zip \xfe\xff"
+    _store(blob)
+    body = client.get("/api/project-snapshot", headers=auth(admin_token)).get_json()
+    assert base64.b64decode(body["contentBase64"]) == blob
+
+
+def test_a_new_admin_can_retrieve_a_project_stored_before_the_account_existed(client, admin_token):
+    # The snapshot deliberately survives changes to the user list, including a
+    # credentials reset that wipes the database: retrieval is gated on holding
+    # admin credentials at request time, not on who uploaded.
+    _store()
+    create_user(client, "second-admin", "second-pass", token=admin_token, role="admin")
+    second = token_for(client, "second-admin", "second-pass")
+    resp = client.get("/api/project-snapshot", headers=auth(second))
+    assert resp.status_code == 200
+    assert resp.get_json()["projectName"] == "Traffic Light"
+
+
+# --- capabilities ---------------------------------------------------------
+
+
+def test_capabilities_advertises_snapshot_support(client):
+    # Unauthenticated on purpose: a client decides whether to build and send a
+    # snapshot before it has logged in to the device.
+    assert client.get("/api/capabilities").get_json()["projectSnapshot"] is True

--- a/tests/pytest/restapi/test_project_snapshot.py
+++ b/tests/pytest/restapi/test_project_snapshot.py
@@ -101,6 +101,18 @@ def test_clear_then_no_stage_erases_the_previous_project():
     assert project_snapshot.has_snapshot() is False
 
 
+def test_a_stranded_staged_snapshot_is_never_promoted_by_a_later_build():
+    # If an upload dies after staging but before the compile thread starts
+    # (a failed extract, say), nothing discards what it staged. The next
+    # upload's clear() has to be what removes it -- otherwise that build would
+    # promote a snapshot belonging to an upload that never landed, and the
+    # device would advertise a project it is definitely not running.
+    project_snapshot.stage(b"stranded", _metadata(projectName="Never Landed"))
+    project_snapshot.clear()  # the next upload
+    assert project_snapshot.promote() is False
+    assert project_snapshot.has_snapshot() is False
+
+
 def test_a_second_upload_replaces_the_first():
     _store(b"first", projectName="First")
     project_snapshot.clear()

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -334,7 +334,6 @@ def handle_upload_file(data: dict) -> dict:
         # client keep working, and the device stops advertising a project it
         # is no longer running.
         project_snapshot.clear()
-        snapshot_error = stage_project_snapshot()
 
         if os.path.exists(extract_dir):
             shutil.rmtree(extract_dir)
@@ -362,6 +361,16 @@ def handle_upload_file(data: dict) -> dict:
         # ccache contents before invoking compile.sh. Older editors
         # don't pass this flag, so behaviour for them is unchanged.
         clean_build = flask.request.args.get("clean") == "1"
+
+        # Stage the snapshot only once the program itself is safely in place.
+        # run_compile's `finally` is what promotes or discards a staged
+        # snapshot, so staging before the extract would leave one stranded if
+        # the extract threw -- the compile thread never starts, nothing
+        # discards it, and the NEXT successful build would promote a snapshot
+        # belonging to an upload that never landed. The clear() above has
+        # already erased the old one either way, which is correct: the program
+        # it described is gone.
+        snapshot_error = stage_project_snapshot()
 
         # Start compilation in a separate thread
         build_state.status = BuildStatus.COMPILING

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -21,6 +21,7 @@ from typing import Callable, Final, Optional
 import flask
 import flask_login
 
+from webserver import project_snapshot
 from webserver.credentials import CertGen
 from webserver.debug_websocket import init_debug_websocket
 from webserver.discovery.discovery_routes import discovery_bp
@@ -30,10 +31,10 @@ from webserver.plcapp_management import (
     MAX_FILE_SIZE,
     BuildStatus,
     analyze_zip,
+    apply_vpp_plugin_conf,
     build_state,
     run_compile,
     safe_extract,
-    apply_vpp_plugin_conf,
     update_plugin_configurations,
 )
 from webserver.restapi import (
@@ -243,6 +244,48 @@ def restapi_callback_get(argument: str, data: dict) -> dict:
     return {"error": "Unknown argument"}
 
 
+def stage_project_snapshot() -> str:
+    """Stage the optional source-project snapshot that rides along with an upload.
+
+    Returns an empty string when there was nothing to store or it was stored,
+    and a human-readable reason otherwise. Never raises: the snapshot is the
+    optional half of the request and must not be able to fail a program upload.
+
+    The two fields are deliberately separate from ``program.zip``. Inside it
+    they would run through ``analyze_zip`` and be extracted into
+    ``core/generated``, where the next upload would wipe them and the compiler
+    would try to build them. The metadata is separate from the archive for the
+    same reason in reverse: the runtime never opens the archive, so anything it
+    needs to say about the stored project has to arrive already parsed.
+    """
+    snapshot_file = flask.request.files.get("snapshot")
+    if snapshot_file is None:
+        return ""
+
+    raw_metadata = flask.request.form.get("snapshot_metadata")
+    if not raw_metadata:
+        return "Snapshot ignored: the upload carried an archive but no snapshot_metadata"
+
+    try:
+        metadata = project_snapshot.normalize_metadata(json.loads(raw_metadata))
+    except json.JSONDecodeError as e:
+        return f"Snapshot ignored: snapshot_metadata is not valid JSON ({e})"
+    except project_snapshot.SnapshotError as e:
+        return f"Snapshot ignored: {e}"
+
+    try:
+        blob = snapshot_file.read()
+    except (OSError, IOError) as e:
+        return f"Snapshot ignored: could not read the uploaded archive ({e})"
+
+    try:
+        project_snapshot.stage(blob, metadata)
+    except project_snapshot.SnapshotError as e:
+        return f"Snapshot ignored: {e}"
+
+    return ""
+
+
 def handle_upload_file(data: dict) -> dict:
     if build_state.status == BuildStatus.COMPILING:
         return {
@@ -279,6 +322,20 @@ def handle_upload_file(data: dict) -> dict:
             }
 
         extract_dir = "core/generated"
+
+        # Point of no return: past here the program on the device is being
+        # replaced, so the stored project snapshot must go with it. Clearing
+        # here rather than on arrival means a rejected upload (bad zip, too
+        # large, runtime busy) leaves the previous program AND its snapshot
+        # untouched, which is the pair that is actually still true.
+        #
+        # An upload carrying no snapshot therefore erases the stored one --
+        # that is the point. Older editors, openplc-cli and any third-party
+        # client keep working, and the device stops advertising a project it
+        # is no longer running.
+        project_snapshot.clear()
+        snapshot_error = stage_project_snapshot()
+
         if os.path.exists(extract_dir):
             shutil.rmtree(extract_dir)
 
@@ -318,7 +375,15 @@ def handle_upload_file(data: dict) -> dict:
 
         task_compile.start()
 
-        return {"UploadFileFail": "", "CompilationStatus": build_state.status.name}
+        # The program upload itself succeeded. A snapshot that could not be
+        # stored is reported alongside rather than as a failure: the device is
+        # running the new program either way, and failing the upload over the
+        # optional half of it would be worse than losing retrievability.
+        return {
+            "UploadFileFail": "",
+            "CompilationStatus": build_state.status.name,
+            "ProjectSnapshotWarning": snapshot_error,
+        }
 
     except (OSError, IOError) as e:
         build_state.status = BuildStatus.FAILED

--- a/webserver/discovery/network_discovery.py
+++ b/webserver/discovery/network_discovery.py
@@ -9,7 +9,9 @@ The protocol is intentionally tiny and stateless:
 
     Request   : "OPENPLC_DISCOVER_V1"          (UTF-8, exact)
     Response  : JSON with {service, protocol_version, runtime_version,
-                           hostname, api_port}
+                           hostname, api_port} plus {project_name,
+                           project_timestamp} when a source project is
+                           stored on the device
 
 Only the magic string is accepted; anything else is dropped silently.
 Replies are unicast to the source address of the request, which is
@@ -26,6 +28,7 @@ import threading
 import time
 from typing import Optional
 
+from webserver import project_snapshot
 from webserver.logger import get_logger
 from webserver.version import RUNTIME_VERSION
 
@@ -136,6 +139,13 @@ class NetworkDiscoveryResponder:
                 ip: ts for ip, ts in self._last_seen.items() if ts >= cutoff
             }
 
+        # Name and timestamp of the stored source project, when there is one.
+        # This is what lets a client populate its "Retrieve Project from PLC"
+        # picker without logging in to every device on the LAN first. Absent
+        # keys mean no stored project, so there is no separate flag.
+        #
+        # Deliberately just these two: they are exactly what the picker shows.
+        # Everything else about the stored project needs authentication.
         payload = json.dumps(
             {
                 "service": "openplc-runtime",
@@ -143,6 +153,7 @@ class NetworkDiscoveryResponder:
                 "runtime_version": RUNTIME_VERSION,
                 "hostname": socket.gethostname(),
                 "api_port": API_PORT,
+                **project_snapshot.advertised_fields(),
             },
             separators=(",", ":"),
         ).encode("utf-8")

--- a/webserver/plcapp_management.py
+++ b/webserver/plcapp_management.py
@@ -1,17 +1,18 @@
-from dataclasses import dataclass, field
-from enum import Enum, auto
+import glob
 import os
 import shutil
-import time
-import zipfile
 import subprocess
 import threading
-import glob
+import time
+import zipfile
+from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import Final
 
+from webserver import project_snapshot
+from webserver.logger import LogParser, get_logger
+from webserver.plugin_config_model import PluginConfig, PluginsConfiguration, PluginType
 from webserver.runtimemanager import RuntimeManager
-from webserver.logger import get_logger, LogParser
-from webserver.plugin_config_model import PluginsConfiguration, PluginConfig, PluginType
 from webserver.vpp_license_debug import derive_license_path, is_inside_root
 
 logger, _ = get_logger("runtime", use_buffer=True)
@@ -619,3 +620,21 @@ def run_compile(runtime_manager: RuntimeManager, cwd: str = "core/generated", cl
         build_state.log(f"[ERROR] Compile orchestrator crashed: {e}\n")
         build_state.status = BuildStatus.FAILED
         build_state.exit_code = -1
+    finally:
+        # The stored project snapshot follows the program exactly. A snapshot
+        # staged by the upload becomes the stored one only once the build has
+        # actually produced a program; any other outcome discards it, and the
+        # upload already cleared whatever was stored before.
+        #
+        # In a `finally` so the outer crash guard above cannot leave a staged
+        # snapshot behind to be promoted by the NEXT build. Discarding is the
+        # honest end state either way: a failed build leaves the device with no
+        # program at all, because compile-clean.sh removes libplc_*.so before it
+        # has a replacement to move into place.
+        try:
+            if build_state.status == BuildStatus.SUCCESS:
+                project_snapshot.promote()
+            else:
+                project_snapshot.discard_staged()
+        except Exception as e:  # never let snapshot bookkeeping mask a build result
+            build_state.log(f"[WARNING] Project snapshot bookkeeping failed: {e}\n")

--- a/webserver/project_snapshot.py
+++ b/webserver/project_snapshot.py
@@ -1,0 +1,248 @@
+"""Storage for the source project snapshot a client sends with an upload.
+
+The editor compiles a project and uploads only the build artifacts, so nothing
+on the device has ever recorded the project the artifacts came from.  This
+module stores an optional snapshot of that project so an admin can retrieve it
+later ("Retrieve Project from PLC").
+
+Two rules shape everything here:
+
+  * **The blob is opaque.**  The runtime never opens the archive, never parses
+    it, never validates its contents.  Everything the device needs to *say*
+    about the stored project arrives as separate metadata alongside the bytes.
+    Keeping this property is what keeps the device side small: the archive
+    format can change entirely without touching the runtime.
+
+  * **The stored project must match the running program.**  An upload clears
+    the snapshot first and only promotes the new one once the build succeeds.
+    A device therefore never advertises a project it is not running, and an
+    upload from a client that sends no snapshot (an older editor, the CLI, any
+    third party) correctly leaves the device with none.
+
+The staged/promoted split exists for the second rule.  ``stage()`` runs when
+the upload arrives, ``promote()`` when the build succeeds, and
+``discard_staged()`` when it fails -- which matches what the build itself does
+to the program: ``compile-clean.sh`` removes ``libplc_*.so`` before it has a
+replacement, so a failed build leaves no program, and "no program, no stored
+project" is the accurate state.
+
+Note the snapshot deliberately survives a credentials reset (``config.py``
+deletes ``restapi.db`` when ``.env`` is regenerated).  Retrieval is gated on
+holding admin credentials at the time of the request, so a freshly created
+admin set is expected to be able to retrieve the stored project.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Final, Optional
+
+from webserver.config import PERSISTENT_DATA_DIR
+from webserver.logger import get_logger
+
+logger, _ = get_logger(__name__)
+
+SNAPSHOT_DIR: Final[Path] = PERSISTENT_DATA_DIR / "project_snapshot"
+
+_PROMOTED_BLOB: Final[Path] = SNAPSHOT_DIR / "project.zip"
+_PROMOTED_META: Final[Path] = SNAPSHOT_DIR / "project.json"
+_STAGED_BLOB: Final[Path] = SNAPSHOT_DIR / "staged.zip"
+_STAGED_META: Final[Path] = SNAPSHOT_DIR / "staged.json"
+
+# Cap for the snapshot field.  Deliberately its own constant and much larger
+# than the program-zip limits in plcapp_management: those guard an archive that
+# gets extracted and compiled, while this one is stored untouched, and a real
+# project carrying its bundled libraries is a great deal bigger than the
+# generated sources.
+MAX_SNAPSHOT_BYTES: Final[int] = 100 * 1024 * 1024
+
+# Bounds on the metadata the device will repeat back to clients.  This is not
+# security -- an authenticated client could write anything -- it just stops a
+# malformed or hostile upload from parking unbounded junk in the discovery
+# payload and the info endpoint.
+_MAX_STRING_LEN: Final[int] = 512
+_MAX_LIBRARIES: Final[int] = 256
+
+
+class SnapshotError(ValueError):
+    """Raised for a snapshot the runtime will not store."""
+
+
+def _ensure_dir() -> None:
+    SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _clean_string(value: Any) -> str:
+    """One metadata string, truncated and stripped of control characters.
+
+    Control characters matter because these values land in a JSON discovery
+    reply and in client UI; a newline in a project name should not be able to
+    reshape either.
+    """
+    if not isinstance(value, str):
+        return ""
+    cleaned = "".join(ch for ch in value if ch.isprintable())
+    return cleaned.strip()[:_MAX_STRING_LEN]
+
+
+def normalize_metadata(raw: Any) -> dict:
+    """Coerce client-supplied metadata into the record the device will serve.
+
+    Unknown keys are dropped rather than stored: everything here is echoed back
+    to other clients, so the shape is the device's, not the uploader's.
+    """
+    if not isinstance(raw, dict):
+        raise SnapshotError("Snapshot metadata must be a JSON object")
+
+    libraries = []
+    raw_libraries = raw.get("libraries")
+    if isinstance(raw_libraries, list):
+        for entry in raw_libraries[:_MAX_LIBRARIES]:
+            if not isinstance(entry, dict):
+                continue
+            name = _clean_string(entry.get("name"))
+            if not name:
+                continue
+            libraries.append(
+                {
+                    "name": name,
+                    "version": _clean_string(entry.get("version")),
+                    "hash": _clean_string(entry.get("hash")),
+                }
+            )
+
+    format_version = raw.get("formatVersion")
+    if not isinstance(format_version, int) or format_version < 1:
+        raise SnapshotError("Snapshot metadata needs an integer formatVersion of 1 or more")
+
+    project_name = _clean_string(raw.get("projectName"))
+    if not project_name:
+        raise SnapshotError("Snapshot metadata needs a projectName")
+
+    return {
+        "formatVersion": format_version,
+        "projectName": project_name,
+        "editorVersion": _clean_string(raw.get("editorVersion")),
+        "uploadedBy": _clean_string(raw.get("uploadedBy")),
+        "timestamp": _clean_string(raw.get("timestamp")),
+        "libraries": libraries,
+    }
+
+
+def clear() -> None:
+    """Remove the stored snapshot and anything staged.
+
+    Called at the start of every upload.  A missing directory is the normal
+    state on a device that has never stored one, not an error.
+    """
+    try:
+        shutil.rmtree(SNAPSHOT_DIR)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("Could not clear the stored project snapshot: %s", exc)
+
+
+def stage(blob: bytes, metadata: dict) -> None:
+    """Replace the stored snapshot with one awaiting a successful build.
+
+    Clearing first is what makes an upload carrying no snapshot erase the old
+    one -- the caller simply does not follow with a stage().
+    """
+    if len(blob) > MAX_SNAPSHOT_BYTES:
+        raise SnapshotError(
+            f"Project snapshot is too large " f"({len(blob)} bytes, limit {MAX_SNAPSHOT_BYTES})"
+        )
+
+    record = dict(metadata)
+    record["sizeBytes"] = len(blob)
+
+    clear()
+    _ensure_dir()
+    try:
+        _STAGED_BLOB.write_bytes(blob)
+        _STAGED_META.write_text(json.dumps(record), encoding="utf-8")
+    except OSError as exc:
+        # Leave nothing half-written: a staged blob without its metadata would
+        # be promoted into a snapshot the info endpoint cannot describe.
+        clear()
+        raise SnapshotError(f"Could not store the project snapshot: {exc}") from exc
+
+    logger.info("Project snapshot staged (%d bytes)", len(blob))
+
+
+def promote() -> bool:
+    """Make the staged snapshot the stored one.  Returns True if one was staged."""
+    if not (_STAGED_BLOB.exists() and _STAGED_META.exists()):
+        return False
+    try:
+        os.replace(_STAGED_BLOB, _PROMOTED_BLOB)
+        os.replace(_STAGED_META, _PROMOTED_META)
+    except OSError as exc:
+        logger.error("Could not promote the staged project snapshot: %s", exc)
+        discard_staged()
+        return False
+    logger.info("Project snapshot promoted")
+    return True
+
+
+def discard_staged() -> None:
+    """Drop a staged snapshot after a failed build."""
+    for path in (_STAGED_BLOB, _STAGED_META):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("Could not discard the staged project snapshot: %s", exc)
+
+
+def read_metadata() -> Optional[dict]:
+    """Metadata for the stored snapshot, or None when none is stored."""
+    try:
+        record = json.loads(_PROMOTED_META.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as exc:
+        logger.warning("Stored project snapshot metadata is unreadable: %s", exc)
+        return None
+    if not isinstance(record, dict):
+        return None
+    # A metadata file without its blob describes nothing retrievable.
+    if not _PROMOTED_BLOB.exists():
+        return None
+    return record
+
+
+def read_blob() -> Optional[bytes]:
+    """Bytes of the stored snapshot, or None when none is stored."""
+    try:
+        return _PROMOTED_BLOB.read_bytes()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.error("Could not read the stored project snapshot: %s", exc)
+        return None
+
+
+def has_snapshot() -> bool:
+    return read_metadata() is not None
+
+
+def advertised_fields() -> dict:
+    """The subset of the metadata the unauthenticated discovery reply carries.
+
+    Name and timestamp only: enough for a client to populate its device picker
+    without a login per device, and nothing beyond what the picker shows.
+    Absent keys mean no stored project, so no separate flag is needed.
+    """
+    record = read_metadata()
+    if record is None:
+        return {}
+    return {
+        "project_name": record.get("projectName", ""),
+        "project_timestamp": record.get("timestamp", ""),
+    }

--- a/webserver/restapi.py
+++ b/webserver/restapi.py
@@ -1,3 +1,4 @@
+import base64
 import os
 from typing import Callable, Optional
 
@@ -16,6 +17,7 @@ from sqlalchemy import text as sa_text
 from werkzeug.security import check_password_hash, generate_password_hash
 
 import webserver.config
+from webserver import project_snapshot
 from webserver.logger import get_logger
 from webserver.retain_config import (
     DEFAULT_FLUSH_SECONDS,
@@ -118,6 +120,10 @@ def restapi_capabilities():
             {
                 "runtimeVersion": RUNTIME_VERSION,
                 "minEditorVersion": MIN_EDITOR_VERSION,
+                # Tells a client it may send a source-project snapshot with an
+                # upload and retrieve it later. Unauthenticated like the rest of
+                # this endpoint, so a client can decide before logging in.
+                "projectSnapshot": True,
             }
         ),
         200,
@@ -806,6 +812,112 @@ def put_retain_config():
         return jsonify({"msg": f"Could not save the settings: {e}"}), 400
 
     return jsonify(saved), 200
+
+
+@restapi_bp.route("/project-snapshot/info", methods=["GET"])
+@jwt_required()
+def get_project_snapshot_info():
+    """Describe the source project stored on this device, if any.
+
+    Authenticated but not admin-gated: this is the metadata a client needs to
+    decide whether retrieving is worth offering, and it says nothing the
+    discovery broadcast does not already hint at. The archive itself is
+    admin-only.
+    ---
+    tags:
+      - Programs
+    security:
+      - BearerAuth: []
+    responses:
+      200:
+        description: Stored project metadata, or present=false when there is none
+        schema:
+          type: object
+          properties:
+            present:
+              type: boolean
+            projectName:
+              type: string
+            editorVersion:
+              type: string
+            uploadedBy:
+              type: string
+            timestamp:
+              type: string
+            sizeBytes:
+              type: integer
+            formatVersion:
+              type: integer
+            libraries:
+              type: array
+              items:
+                type: object
+      401:
+        description: Authentication required
+    """
+    record = project_snapshot.read_metadata()
+    if record is None:
+        return jsonify({"present": False}), 200
+    return jsonify({"present": True, **record}), 200
+
+
+@restapi_bp.route("/project-snapshot", methods=["GET"])
+@jwt_required()
+def get_project_snapshot():
+    """Retrieve the stored source project as a base64 ZIP.
+
+    Admin only. The stored project is NOT encrypted on the device -- anyone
+    with filesystem access can read it -- so this role check is the whole of
+    the access control, not a second layer behind one.
+
+    Base64 inside JSON rather than a binary body on purpose: openplc-web
+    reaches devices through the orchestrator agent's HTTP proxy, which decodes
+    responses as JSON or falls back to text. A binary body does not survive
+    that trip.
+    ---
+    tags:
+      - Programs
+    security:
+      - BearerAuth: []
+    responses:
+      200:
+        description: The stored project archive
+        schema:
+          type: object
+          properties:
+            projectName:
+              type: string
+            filename:
+              type: string
+            contentBase64:
+              type: string
+              description: The project ZIP, base64-encoded
+      401:
+        description: Authentication required
+      403:
+        description: Admin privileges required
+      404:
+        description: No project is stored on this device
+    """
+    if not (current_user and current_user.is_admin()):
+        return jsonify({"msg": "Admin privileges required"}), 403
+
+    record = project_snapshot.read_metadata()
+    blob = project_snapshot.read_blob()
+    if record is None or blob is None:
+        return jsonify({"msg": "No project is stored on this device"}), 404
+
+    return (
+        jsonify(
+            {
+                "projectName": record.get("projectName", ""),
+                "formatVersion": record.get("formatVersion"),
+                "filename": "project.zip",
+                "contentBase64": base64.b64encode(blob).decode("ascii"),
+            }
+        ),
+        200,
+    )
 
 
 @restapi_bp.route("/login", methods=["POST"])


### PR DESCRIPTION
Part of RTOP-272. The device now keeps the source project a program was built from, so it can be retrieved later.

## What this does

`POST /api/upload-file` accepts two new optional fields: `snapshot` (the project archive) and `snapshot_metadata` (JSON). Neither is required, so older editors, `openplc-cli` and any third-party client keep working untouched.

Retrieval is `GET /api/project-snapshot`, admin only, base64 in JSON. `GET /api/project-snapshot/info` reports presence and metadata to any authenticated user, and `/api/capabilities` advertises `projectSnapshot: true` unauthenticated so a client can decide before logging in.

## Two properties worth reviewing against

**The blob is opaque.** Nothing here opens the archive. Everything the device says about the stored project comes from the metadata sent alongside it, which is why the metadata is a separate field rather than something read out of the zip. A test deliberately stores bytes that are not a ZIP at all and retrieves them unchanged; if that ever fails, the archive format has stopped being free to change without touching the runtime.

**The stored project never outlives the program.** An upload clears it at the point of no return, a successful build promotes the staged one, and every other outcome discards it — including the compile orchestrator's own crash guard, which is why the promote/discard sits in a `finally`. This mirrors what the build already does to the program: `compile-clean.sh` removes `libplc_*.so` before it has a replacement, so a failed build leaves no program, and "no program, no stored project" is the accurate state rather than a gap.

Clearing happens at the point of no return rather than on arrival, so an upload rejected earlier (bad zip, too large, runtime busy) leaves the previous program *and* its snapshot intact — that pair is still true.

## Deliberate decisions

- **The archive is not encrypted.** Anyone with filesystem access to the device can read it. The admin role on retrieval is therefore the whole of the access control, not a second layer behind one.
- **The snapshot survives a credentials reset.** `config.py` wipes `restapi.db` when `.env` is regenerated; the snapshot lives elsewhere and is untouched, because retrieval is gated on holding admin credentials at request time rather than on who uploaded.
- **Discovery carries name and timestamp only**, so a client can populate its picker without logging in to every device on the LAN. Absent keys mean no stored project, so there is no separate flag.

## Incidental

Adding the snapshot store to the discovery responder gave it a transitive import of `webserver.config`, whose import-time side effects need writable paths. The new root `tests/pytest/conftest.py` supplies them for every suite rather than leaving each module to discover that dependency for itself.

## Testing

31 new unit tests; 121 pass across `restapi` + `discovery`. The `modbus_master` and `opcua` failures in the full suite are pre-existing on `development` (missing `asyncua` / `pytest_asyncio`) and unchanged by this branch.

Verified end to end on real hardware (aarch64 device at 192.168.2.4, full `install.sh`):

| Check | Result |
|---|---|
| `/api/capabilities` advertises support, unauthenticated | pass |
| Upload + snapshot, build SUCCESS, promoted with full metadata | pass |
| Retrieved archive byte-identical, unpacks to the original tree | pass |
| Retrieval refused 403 for a non-admin account | pass |
| Discovery carries `project_name` / `project_timestamp` | pass |
| Upload with **no** snapshot field clears the stored project, discovery keys drop | pass |
| Failed build leaves **no** `.so` and **no** stored project | pass |
| Snapshot without metadata / bad JSON / no projectName: upload succeeds, snapshot ignored with a reason | pass |
| Snapshot survives a service restart | pass |

The failed-build case needed a genuine compile error to be meaningful — the first two attempts appended to a file with no trailing newline and landed inside a `//` comment, so they built fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpea15BYCgPSqpatpveRk1