### PR TITLE
RTOP-278 Runtime: rescue a device whose accounts contain no administrator

### DIFF
--- a/tests/pytest/restapi/test_repair_missing_admin.py
+++ b/tests/pytest/restapi/test_repair_missing_admin.py
@@ -1,0 +1,167 @@
+"""A device left with accounts but no administrator.
+
+That state is a dead end rather than an inconvenience: once any user exists,
+``create-user`` refuses a non-admin caller and ``update-user`` refuses a role
+change from one, so no sequence of API calls produces an admin. Everything
+admin-gated stays unreachable, and nothing surfaces it until someone tries.
+
+Devices reach it by upgrading through an early build of the roles feature,
+whose ``role`` column was nullable with no default. ``apply_user_schema_
+migrations`` does not cover it -- that only runs when the column is ABSENT, so
+a database that already has one keeps whatever it holds.
+
+The repair promotes a single account and refuses to choose among several. Both
+halves matter: the first rescues the devices that exist, and the second keeps
+the runtime from silently handing administrator rights to whichever account
+happens to sort first.
+"""
+
+from conftest import auth, create_user, token_for
+from sqlalchemy import text as sa_text
+
+from webserver.restapi import ADMIN_ROLE, USER_ROLE, User, admin_count, db, repair_missing_admin
+
+
+def _add_user(username, role):
+    """Insert an account directly, bypassing the role rules the API enforces.
+
+    The states under test cannot be produced through the API at all -- that is
+    the whole problem -- so they have to be built underneath it.
+    """
+    user = User(username=username, role=role)
+    user.set_password("pass-for-" + username)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _roles():
+    return {user.username: user.role for user in User.query.all()}
+
+
+# --- the repair ----------------------------------------------------------
+
+
+def test_a_lone_non_admin_account_is_promoted(app):
+    _add_user("op", USER_ROLE)
+    assert repair_missing_admin() is True
+    assert _roles() == {"op": ADMIN_ROLE}
+
+
+def test_a_null_role_counts_as_no_admin_rather_than_crashing(app):
+    # Rebuilt as the schema an affected device actually carries, copied from
+    # the hardware unit this was found on:
+    #
+    #     role VARCHAR(20)      -- nullable, no default
+    #
+    # The current model declares NOT NULL DEFAULT 'admin', so a NULL role
+    # cannot be created through it or even inserted into the table it builds.
+    # Reproducing the old shape is the only way to check the repair copes with
+    # what is out there rather than with what we would write today.
+    db.session.execute(sa_text("DROP TABLE users"))
+    db.session.execute(
+        sa_text(
+            "CREATE TABLE users ("
+            " id INTEGER NOT NULL,"
+            " username TEXT NOT NULL,"
+            " password_hash TEXT NOT NULL,"
+            " role VARCHAR(20),"
+            " PRIMARY KEY (id),"
+            " UNIQUE (username))"
+        )
+    )
+    db.session.execute(
+        sa_text("INSERT INTO users (username, password_hash, role) VALUES ('op', 'x', NULL)")
+    )
+    db.session.commit()
+
+    assert admin_count() == 0
+    assert repair_missing_admin() is True
+    assert _roles() == {"op": ADMIN_ROLE}
+
+
+def test_the_repair_is_a_no_op_on_every_later_boot(app):
+    _add_user("op", USER_ROLE)
+    assert repair_missing_admin() is True
+    # Second boot: an admin now exists, so there is nothing to do. This has to
+    # be a real no-op, not merely idempotent by luck.
+    assert repair_missing_admin() is False
+    assert _roles() == {"op": ADMIN_ROLE}
+
+
+def test_several_accounts_with_no_admin_are_left_alone(app):
+    # The runtime has no basis for choosing which account becomes the
+    # administrator, so it refuses rather than picking one silently.
+    _add_user("alice", USER_ROLE)
+    _add_user("bob", USER_ROLE)
+    assert repair_missing_admin() is False
+    assert _roles() == {"alice": USER_ROLE, "bob": USER_ROLE}
+
+
+def test_several_accounts_with_no_admin_are_reported(app, caplog):
+    # Nothing else will ever surface this state -- an operator only finds it by
+    # hitting a 403 on something that should have worked.
+    _add_user("alice", USER_ROLE)
+    _add_user("bob", USER_ROLE)
+    with caplog.at_level("ERROR"):
+        repair_missing_admin()
+    logged = caplog.text
+    assert "alice" in logged and "bob" in logged
+
+
+def test_an_existing_admin_is_untouched(app):
+    _add_user("admin", ADMIN_ROLE)
+    _add_user("op", USER_ROLE)
+    assert repair_missing_admin() is False
+    assert _roles() == {"admin": ADMIN_ROLE, "op": USER_ROLE}
+
+
+def test_a_device_with_no_accounts_is_left_to_bootstrap(app):
+    # A fresh device is not broken, it is empty. The bootstrap path already
+    # makes the first account an admin.
+    assert repair_missing_admin() is False
+    assert User.query.count() == 0
+
+
+def test_bootstrap_still_produces_an_admin_after_the_repair_runs(client):
+    assert repair_missing_admin() is False
+    resp = create_user(client, "first", "first-pass")
+    assert resp.status_code == 201
+    assert resp.get_json()["role"] == ADMIN_ROLE
+
+
+# --- what the repair actually restores -----------------------------------
+
+
+def test_the_promoted_account_can_use_admin_only_endpoints(client, app):
+    # The point of the repair, end to end: before it, this account cannot reach
+    # anything admin-gated and cannot be granted access by any API call.
+    _add_user("op", USER_ROLE)
+    token = token_for(client, "op", "pass-for-op")
+    assert client.get("/api/project-snapshot", headers=auth(token)).status_code == 403
+
+    repair_missing_admin()
+
+    # A fresh token, because the role is read from the database per request but
+    # the identity was established before the promotion.
+    token = token_for(client, "op", "pass-for-op")
+    assert client.get("/api/whoami", headers=auth(token)).get_json()["role"] == ADMIN_ROLE
+    # 404 rather than 403: reachable now, with nothing stored to hand back.
+    assert client.get("/api/project-snapshot", headers=auth(token)).status_code == 404
+
+
+def test_without_the_repair_there_is_no_way_back(client, app):
+    # Documents why this cannot be left to the operator: with no admin, neither
+    # of the two endpoints that could create one will act.
+    _add_user("op", USER_ROLE)
+    token = token_for(client, "op", "pass-for-op")
+
+    created = create_user(client, "new-admin", "pw", token=token, role=ADMIN_ROLE)
+    assert created.status_code == 403
+
+    promoted = client.put(
+        f"/api/update-user/{User.query.filter_by(username='op').one().id}",
+        json={"role": ADMIN_ROLE},
+        headers=auth(token),
+    )
+    assert promoted.status_code == 403

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -43,6 +43,7 @@ from webserver.restapi import (
     db,
     register_callback_get,
     register_callback_post,
+    repair_missing_admin,
     restapi_bp,
 )
 from webserver.runtimemanager import RuntimeManager
@@ -457,6 +458,13 @@ def run_https():
             # users.role column in place; no-op once present).
             apply_user_schema_migrations()
             db.session.commit()
+            # Rescue a device left with accounts but no admin. Unlike the
+            # schema migration above this is a DATA repair, and it has to run
+            # separately: the migration only fires when the role column is
+            # missing, so a database that already has one keeps whatever values
+            # it holds -- including none of them being 'admin'. Without an
+            # admin there is no API path back to having one.
+            repair_missing_admin()
             # logger.info("Database tables created successfully.")
         except Exception:
             # logger.error("Error creating database tables: %s", e)

--- a/webserver/restapi.py
+++ b/webserver/restapi.py
@@ -258,7 +258,18 @@ def repair_missing_admin() -> bool:
 
     user = users[0]
     user.role = ADMIN_ROLE
-    db.session.commit()
+    try:
+        db.session.commit()
+    except Exception as exc:
+        # The caller runs inside a broad `except Exception: pass` that exists
+        # for the schema setup around it. Reporting here means a failed repair
+        # is not swallowed by that: it only ever gets one chance per boot, and
+        # a device that silently stayed unrepairable is the hardest version of
+        # this problem to diagnose.
+        db.session.rollback()
+        logger.error("Could not promote '%s' to administrator: %s", user.username, exc)
+        return False
+
     logger.warning(
         "Account '%s' was the only account on this device and held no "
         "administrator role, which leaves admin-only operations permanently "

--- a/webserver/restapi.py
+++ b/webserver/restapi.py
@@ -212,6 +212,62 @@ def apply_user_schema_migrations():
         )
 
 
+def repair_missing_admin() -> bool:
+    """Rescue a device whose accounts contain no admin at all.
+
+    That state is a dead end. Once any user exists, ``create-user`` refuses a
+    caller who is not an admin and ``update-user`` refuses a role change from
+    one, so there is no sequence of API calls that produces an admin. Every
+    admin-gated operation is permanently unreachable, and nothing surfaces it
+    until someone tries one.
+
+    Devices reach it by upgrading through an early build of the roles feature,
+    whose ``role`` column was nullable with no default and whose rows landed on
+    ``user``. ``apply_user_schema_migrations`` does not help: it only runs when
+    the column is ABSENT, so a database that already has one is left alone
+    whatever is in it.
+
+    Exactly one account is promoted, because a single-user device has no
+    ambiguity about who the administrator is. With several accounts the runtime
+    has no basis for picking a winner, so it refuses to guess and says so
+    loudly instead -- that combination should barely exist in the field, since
+    multiple accounts only became possible when roles did.
+
+    Returns True when an account was promoted. Safe on every boot: a no-op the
+    moment any admin exists.
+    """
+    if admin_count() > 0:
+        return False
+
+    users = User.query.order_by(User.id).all()
+    if not users:
+        # Fresh device. The bootstrap path already makes the first account an
+        # admin, so there is nothing to repair.
+        return False
+
+    if len(users) > 1:
+        logger.error(
+            "No administrator account exists and there are %d accounts (%s). "
+            "The runtime will not choose one. Admin-only operations stay "
+            "unavailable until an administrator is restored directly in the "
+            "user database.",
+            len(users),
+            ", ".join(user.username for user in users),
+        )
+        return False
+
+    user = users[0]
+    user.role = ADMIN_ROLE
+    db.session.commit()
+    logger.warning(
+        "Account '%s' was the only account on this device and held no "
+        "administrator role, which leaves admin-only operations permanently "
+        "unreachable. Promoted it to administrator.",
+        user.username,
+    )
+    return True
+
+
 @jwt.user_identity_loader
 def user_identity_lookup(user):
     return str(user.id)


### PR DESCRIPTION
Part of RTOP-272, though independent of the snapshot feature — this is a pre-existing dead end that surfaced while testing RTOP-273 on hardware.

## The state

A device can hold accounts with none of them an admin, and there is no way out through the API:

- `create-user` refuses once any user exists unless the caller is an admin (`restapi.py:274-283`)
- `update-user` refuses a role change unless the caller is an admin (`restapi.py:509-511`)

So no admin can be created and nobody can be promoted. Every admin-gated operation is permanently unreachable, and nothing surfaces it until someone hits a 403 on something that should have worked. A test in this PR pins that down, because it is the reason this cannot be left to an operator.

## How devices get here — not the expected route

`apply_user_schema_migrations` backfills existing rows to `admin`, but **only when the `role` column is absent**. A database that already has one is left alone whatever it holds.

The hardware unit this was found on carries:

```
role VARCHAR(20)      -- nullable, no default
```

against a current model of `NOT NULL DEFAULT 'admin'`. So this is a database from an **early build of the roles feature**, not a pre-roles one — the migration had nothing to do, and the rows stayed on `user`. That widens the at-risk population beyond "upgraded from before roles existed", and those devices are invisible until someone tries an admin operation.

## The rule

- **Exactly one account, no admin** → promote it. A single-user device has no ambiguity about who the administrator is.
- **Several accounts, no admin** → do not promote, and log an error naming them. The runtime has no basis for choosing, and silently handing admin to whichever account sorts first is worse than leaving the state in place. Nothing else will ever report it.
- **No accounts** → no-op; bootstrap already makes the first account an admin.
- **An admin exists** → no-op on every boot, tested explicitly rather than assumed.

Kept out of `apply_user_schema_migrations` because it is a *data* repair, not a schema one, and it has to run when the schema is already current — which is exactly the case that produced the problem.

## Testing

10 unit tests; 132 pass across `restapi` + `discovery`.

The NULL-role test rebuilds the table with the device's actual schema, because the current model cannot produce or even store a NULL role — testing against the shape we would write today would prove nothing about what is in the field. An earlier version of that test passed `role=None` through the model and silently got `admin` from the Python-side default, i.e. tested nothing.

**Hardware verification** — the device at 192.168.2.4 was genuinely in this state, so this is a real repro rather than a simulated one:

| Step | Result |
|---|---|
| Set `op` back to `role=user` (as the device was found), restart | Promoted to `admin` on boot |
| Log line | `Account 'op' was the only account on this device and held no administrator role… Promoted it to administrator.` |
| `GET /api/project-snapshot` as `op` | **200** — was 403 before the fix |
| Second restart | Role unchanged, no promotion, nothing logged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpea15BYCgPSqpatpveRk1