### PR TITLE
RTOP-272: Retrieve Project from PLC (runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The processes communicate via Unix domain sockets (`/run/runtime/plc_runtime.soc
 - [Editor Integration](docs/EDITOR_INTEGRATION.md) - How OpenPLC Editor communicates with the runtime
 - [Docker Deployment](docs/DOCKER.md) - Container usage and configuration
 - [Compilation Flow](docs/COMPILATION_FLOW.md) - How programs are built and loaded
+- [Retrieve Project from PLC](docs/RETRIEVE_PROJECT.md) - Storing the source project on a device and pulling it back
 - [Troubleshooting](docs/TROUBLESHOOTING.md) - Common issues and solutions
 
 ### Advanced Topics

--- a/docs/RETRIEVE_PROJECT.md
+++ b/docs/RETRIEVE_PROJECT.md
@@ -1,0 +1,223 @@
+# Retrieve Project from PLC
+
+A device keeps a copy of the source project it is running, so the project can be
+opened again from a machine that does not have it. Upload a program from the
+OpenPLC Editor or from openplc-web, and the source project travels with it;
+later, anyone with an administrator account on that device can pull it back.
+
+This answers the everyday case where the device is the only remaining record: an
+engineer left, a laptop died, a panel has been running for two years and nobody
+is sure which version of the project is in it.
+
+## Read this first: the stored project is not encrypted
+
+**The project is stored as a plain ZIP file on the device's filesystem. Anyone
+who can read that filesystem can read the project** -- over SSH, with physical
+access to the storage, from a backup image, or from a mounted volume in a
+container deployment.
+
+The access control on this feature is a single role check on the retrieval
+endpoint: the HTTP API will not hand the archive to a non-administrator. That is
+the whole of it. It protects the network path and nothing else.
+
+There is also **no integrity guarantee.** Nothing signs or checksums the stored
+project, so a project replaced on disk by someone with filesystem access is
+retrieved as if it were the original, and neither the device nor the client can
+tell. Do not describe this feature as verified, trusted, or tamper-proof,
+because it is none of those things.
+
+One more thing worth knowing: the **project name and its timestamp are
+advertised in the unauthenticated UDP discovery reply**, which is how a client
+can show what a device holds before anyone signs in. The name of a project is
+therefore readable by anything on the same network. The archive is not.
+
+If a deployment needs the project protected at rest, the answer is full-disk or
+filesystem-level encryption on the device. This feature does not provide it and
+is not a substitute for it.
+
+## What is stored
+
+The complete source project as the editor holds it -- POUs, data types, global
+variable lists, device and pin configuration, the project manifest -- plus a
+copy of every library the project references.
+
+The `build/` directory is not included. It is generated output, it is the
+largest part of a project, and it is reproduced by compiling.
+
+The archive is capped at 100 MB (`MAX_SNAPSHOT_BYTES` in
+`webserver/project_snapshot.py`). An upload carrying a larger one is accepted as
+a program upload, but the project is not stored, and the response says so.
+
+It lives beside the runtime's other persistent state, in `project_snapshot/`
+under the persistent data directory:
+
+| Deployment | Path |
+| --- | --- |
+| Native Linux | `/var/lib/openplc-runtime/project_snapshot/` |
+| Container | `/var/run/runtime/project_snapshot/` |
+| Overridden | `$OPENPLC_PERSISTENT_DATA_DIR/project_snapshot/` |
+
+## How it stays current
+
+The stored project always describes the program the device is actually running,
+which takes three rules working together.
+
+**Every upload replaces it.** When an upload reaches the point where the
+existing program is being overwritten, the stored project is erased. The new one
+is written only after the new program is safely in place.
+
+**An upload that carries no project erases the stored one.** This is deliberate,
+not an oversight. `openplc-cli`, older editors, and third-party clients upload
+programs without a source project; if the previous one survived, the device would
+advertise a project it is no longer running, which is worse than advertising
+nothing.
+
+**A failed compile leaves nothing behind.** The new project is held aside while
+the build runs and becomes the stored one only if the build succeeds. Any other
+outcome discards it. This matches what happens to the program itself: a failed
+build leaves the device with no program at all, so leaving a stored project
+would describe something that is not there.
+
+The upshot is that a device never advertises a project it is not running. It may
+advertise none -- that is the honest answer after a CLI upload or a failed build.
+
+## Retrieving
+
+The flow is the same on both clients: **File -> Retrieve Project from PLC**.
+
+1. **Pick a device.** The desktop editor scans the local network by UDP
+   broadcast; openplc-web asks each orchestrator's agent to run the same scan
+   against the runtimes it manages, so both read the same source of truth -- the
+   runtime's own advertisement. Each row shows the stored project's name and
+   timestamp. A device storing nothing is shown as such and cannot be chosen.
+
+2. **Give up the current connection, if it costs one.** The client holds a
+   session for one device at a time, so retrieving from a different device ends
+   the session you have. When that applies, you are told before it happens.
+   Picking the device you are already signed in to reuses that session and skips
+   straight to the retrieval.
+
+3. **Sign in as an administrator.** Any authenticated user can see *that* a
+   project is stored and what it is called; only an administrator can retrieve
+   the archive itself. A non-administrator who performed the upload still cannot
+   retrieve it.
+
+4. **The project opens.** It is unpacked into a scratch directory and opened as
+   an ordinary project.
+
+5. **Libraries are reconciled.** Each library the project carries is compared
+   against the ones on this machine by content hash, not by version number --
+   two different builds can carry the same version label. Libraries that are
+   missing, or present but different from what the project was built against,
+   are offered for installation. A library that is present and identical needs
+   nothing.
+
+### A retrieved project has no home yet
+
+It was unpacked into a scratch directory, not into a location anyone chose, so
+**Save is refused and points at Save As.** Saving in place would report success
+for work that is not where the user thinks it is, and on the desktop it would
+sit in a temporary directory. Use **File -> Save As** to give it a home; from
+then on it saves normally.
+
+Compiling a retrieved project works before saving it: the build's own internal
+flush is exempt from that refusal, because refusing it would not protect
+anything -- it would only stop the project from compiling.
+
+Save As is not yet implemented in openplc-web, where projects live in the user's
+account rather than on disk (tracked as RTOP-280). Until it is, retrieve on the
+web opens the project for inspection and compilation; keeping a copy means
+opening it in the desktop editor.
+
+## HTTP API
+
+Both endpoints require authentication. See [API.md](API.md) for the
+authentication flow.
+
+### `GET /api/project-snapshot/info`
+
+What is stored, without the archive. Authenticated, but not restricted to
+administrators: this is what a client needs to decide whether retrieving is
+worth offering, and it says nothing the discovery reply does not already carry.
+
+```json
+{
+  "present": true,
+  "projectName": "Traffic Light",
+  "editorVersion": "1.2.0",
+  "uploadedBy": "operator",
+  "timestamp": "2026-08-31T12:00:00Z",
+  "sizeBytes": 48213,
+  "formatVersion": 1,
+  "libraries": [{ "name": "oscat-basic", "version": "3.3.4", "hash": "9f2c..." }]
+}
+```
+
+When the device stores nothing: `{"present": false}`.
+
+### `GET /api/project-snapshot`
+
+The archive itself. **Administrators only** -- a non-administrator gets `403`.
+`404` when nothing is stored.
+
+```json
+{
+  "projectName": "Traffic Light",
+  "formatVersion": 1,
+  "filename": "project.zip",
+  "contentBase64": "UEsDBBQ..."
+}
+```
+
+The archive is base64 inside JSON rather than a binary body because openplc-web
+reaches devices through the orchestrator agent's HTTP proxy, which decodes
+responses as JSON or falls back to text; a binary body does not survive that
+trip.
+
+### Discovery reply
+
+The UDP discovery reply on port 33333 carries two extra fields when a project is
+stored:
+
+```json
+{
+  "service": "openplc-runtime",
+  "project_name": "Traffic Light",
+  "project_timestamp": "2026-08-31T12:00:00Z"
+}
+```
+
+Both keys are **absent**, not empty, when nothing is stored -- which is what lets
+a client distinguish "nothing stored" from "stored but unnamed" without a
+separate flag. This reply is not authenticated.
+
+### Uploading with a project
+
+`POST /api/upload-file` takes the archive as an additional multipart part
+alongside the program. Clients that do not send one keep working unchanged; see
+"How it stays current" for what that means for anything already stored.
+
+The `projectSnapshot: true` capability flag tells a client the device supports
+this at all.
+
+## When a device has no administrator
+
+Retrieval needs an administrator, so a device whose accounts contain none cannot
+be retrieved from -- and, before this feature, nobody noticed, because nothing
+else required the role.
+
+The runtime repairs the clear-cut case at startup: **if there is exactly one
+account and it is not an administrator, it is promoted.** A sole user is already
+the whole of that device's administration, and the alternative is a device
+nobody can retrieve from.
+
+With several non-administrator accounts, nothing is promoted. Choosing one of
+them would be inventing an authority the deployment never granted, and there is
+no basis for picking. Recovering that device means restoring an administrator
+account by other means.
+
+## Related
+
+- [API.md](API.md) -- the REST API and its authentication
+- [SECURITY.md](SECURITY.md) -- authentication, TLS, and file validation
+- [EDITOR_INTEGRATION.md](EDITOR_INTEGRATION.md) -- how the editor talks to the runtime

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -180,6 +180,34 @@ The extraction process includes additional safety measures:
 3. **Directory Creation**: Creates necessary subdirectories safely
 4. **Atomic Operations**: Extraction is all-or-nothing
 
+## Stored Source Project
+
+A device keeps a copy of the source project it is running so it can be retrieved
+later (see [RETRIEVE_PROJECT.md](RETRIEVE_PROJECT.md)). Its security properties
+are deliberately narrow, and worth stating plainly.
+
+**It is not encrypted.** The project is a plain ZIP file under the persistent
+data directory. Anyone who can read the device's filesystem can read the
+project -- over SSH, with physical access, from a backup image, or from a
+mounted volume in a container deployment.
+
+**The access control is one role check.** `GET /api/project-snapshot` refuses
+the archive to anyone who is not an administrator. That protects the network
+path and nothing else; it is not a second layer behind encryption, because there
+is no encryption behind it.
+
+**There is no integrity guarantee.** Nothing signs or checksums the stored
+project. A project replaced on disk is retrieved as if it were the original, and
+neither the device nor the client can tell.
+
+**The project name is advertised unauthenticated.** The UDP discovery reply on
+port 33333 carries the stored project's name and timestamp so clients can
+populate a device picker before anyone signs in. Anything on the same network
+can read them. The archive itself is never served over discovery.
+
+If a deployment needs the project protected at rest, use full-disk or
+filesystem-level encryption on the device. This feature is not a substitute.
+
 ## Process Security
 
 ### Privilege Requirements

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,0 +1,30 @@
+"""Test-wide bootstrap for modules that reach ``webserver.config``.
+
+``webserver.config`` has import-time side effects: it resolves a persistent
+data dir, creates it, writes a ``.env`` and reads secrets out of it. The
+platform defaults are absolute paths (``/run/runtime``, ``/var/lib/...``) that
+are read-only or absent on a developer machine, so importing anything that
+transitively pulls in ``webserver.config`` fails at collection time unless the
+overrides are in place first.
+
+Pointing them at a throwaway temp dir here -- in the ROOT conftest, which pytest
+imports before any test module -- means a test module does not have to know
+whether its import graph happens to reach config. It reaches it more often than
+it looks: the discovery responder, for one, reports the stored project name, so
+it now depends on the snapshot store, which depends on config.
+
+``setdefault`` throughout, so a suite that wants its own directories (see
+``restapi/conftest.py``) still gets them.
+"""
+
+import os
+import secrets
+import tempfile
+
+_TMP = tempfile.mkdtemp(prefix="openplc-tests-")
+os.environ.setdefault("OPENPLC_RUNTIME_DIR", os.path.join(_TMP, "run"))
+os.environ.setdefault("OPENPLC_PERSISTENT_DATA_DIR", os.path.join(_TMP, "data"))
+os.environ.setdefault("SQLALCHEMY_DATABASE_URI", f"sqlite:///{os.path.join(_TMP, 'test.db')}")
+os.environ.setdefault("JWT_SECRET_KEY", secrets.token_hex(32))
+os.environ.setdefault("PEPPER", secrets.token_hex(32))
+os.environ.setdefault("FLASK_ENV", "development")

--- a/tests/pytest/restapi/test_capabilities.py
+++ b/tests/pytest/restapi/test_capabilities.py
@@ -48,6 +48,7 @@ def test_capabilities_reports_runtime_version_and_editor_floor(client):
     assert body == {
         "runtimeVersion": RUNTIME_VERSION,
         "minEditorVersion": MIN_EDITOR_VERSION,
+        "projectSnapshot": True,
     }
 
 

--- a/tests/pytest/restapi/test_project_snapshot.py
+++ b/tests/pytest/restapi/test_project_snapshot.py
@@ -311,3 +311,169 @@ def test_capabilities_advertises_snapshot_support(client):
     # Unauthenticated on purpose: a client decides whether to build and send a
     # snapshot before it has logged in to the device.
     assert client.get("/api/capabilities").get_json()["projectSnapshot"] is True
+
+
+# --- the size guard at the boundary it defends ---------------------------
+#
+# `test_an_oversized_snapshot_is_refused` exercises `stage()` directly, which
+# proves the cap fires once the bytes already exist. The point of the guard is
+# that they never do: the route is authenticated but not admin-gated, so any
+# account could otherwise have an arbitrarily large part spooled to disk and
+# pulled into memory before anything refused it.
+
+
+def _post_snapshot(client, admin_token, blob, *, metadata=None):
+    """Post a snapshot part through the upload endpoint's staging helper."""
+    import io
+
+    from webserver import app as app_module
+
+    payload = {
+        "snapshot": (io.BytesIO(blob), "project.zip"),
+        "snapshot_metadata": json.dumps(
+            metadata
+            if metadata is not None
+            else {"formatVersion": 1, "projectName": "Traffic Light"}
+        ),
+    }
+    with app_module.app.test_request_context(
+        "/api/upload-file", method="POST", data=payload, content_type="multipart/form-data"
+    ):
+        return app_module.stage_project_snapshot()
+
+
+def test_an_oversized_part_is_refused_without_being_read_into_memory(client):
+    """The refusal must happen during the read, not after it.
+
+    Asserting only on the message would pass against the old code too, because
+    `stage()` rejected an oversized archive with the same words -- after the
+    whole thing was already in memory. So the stream itself is the assertion: it
+    refuses to hand over more than the guard is allowed to ask for.
+    """
+    from werkzeug.datastructures import FileStorage
+    from werkzeug.datastructures import MultiDict
+
+    from webserver import app as app_module
+
+    cap = project_snapshot.MAX_SNAPSHOT_BYTES
+
+    class Tripwire:
+        """Behaves like a huge upload, and objects to being swallowed whole."""
+
+        def __init__(self):
+            self.served = 0
+
+        def read(self, size=-1):
+            if size is None or size < 0:
+                raise AssertionError("unbounded read of the snapshot part")
+            self.served += size
+            if self.served > cap + 1:
+                raise AssertionError(f"read {self.served} bytes past the {cap} cap")
+            return b"x" * size
+
+    stream = Tripwire()
+    with app_module.app.test_request_context("/api/upload-file", method="POST"):
+        import flask
+
+        flask.request.files = MultiDict(
+            {"snapshot": FileStorage(stream=stream, filename="project.zip")}
+        )
+        flask.request.form = MultiDict(
+            {"snapshot_metadata": json.dumps({"formatVersion": 1, "projectName": "Big"})}
+        )
+        reason = app_module.stage_project_snapshot()
+
+    assert "too large" in reason
+    assert project_snapshot.has_snapshot() is False
+    # Nothing staged either: a refused archive must not sit in the store waiting
+    # for the next successful build to promote it.
+    assert project_snapshot._STAGED_BLOB.exists() is False
+
+
+def test_an_archive_at_the_limit_is_still_accepted(client, admin_token):
+    # The guard reads one byte past the cap to decide, so the boundary itself
+    # has to keep working.
+    at_limit = b"y" * project_snapshot.MAX_SNAPSHOT_BYTES
+
+    reason = _post_snapshot(client, admin_token, at_limit)
+
+    assert reason == ""
+    assert project_snapshot.promote() is True
+    assert len(project_snapshot.read_blob()) == project_snapshot.MAX_SNAPSHOT_BYTES
+
+
+def test_the_whole_request_is_bounded_at_the_http_layer(client):
+    # A backstop under the per-part checks: those run only after Werkzeug has
+    # parsed and spooled the body, so the body itself is capped first.
+    from webserver import app as app_module
+
+    limit = app_module.app.config["MAX_CONTENT_LENGTH"]
+    assert limit is not None
+    assert limit > project_snapshot.MAX_SNAPSHOT_BYTES
+
+
+# --- an interrupted promote is diagnosable -------------------------------
+
+
+def test_a_blob_left_without_metadata_says_so_in_the_log(caplog):
+    # `promote()` moves two files, so a power cut between them can leave a blob
+    # with no metadata. Reporting "nothing stored" is correct; doing it in
+    # silence leaves no way to tell that from a device that never had one.
+    _store()
+    project_snapshot._PROMOTED_META.unlink()
+
+    with caplog.at_level("WARNING"):
+        assert project_snapshot.read_metadata() is None
+
+    assert any("no metadata beside it" in record.message for record in caplog.records)
+
+
+# --- the advertised fields cache -----------------------------------------
+#
+# The discovery responder reads these on every probe, so they are held in
+# memory. A cache that can go stale would make the device advertise a project it
+# is no longer running, which is the one thing this whole design refuses to do.
+
+
+def test_what_the_device_advertises_follows_every_change_to_the_store():
+    assert project_snapshot.advertised_fields() == {}
+
+    _store(projectName="First")
+    assert project_snapshot.advertised_fields()["project_name"] == "First"
+
+    # A second upload's build succeeding replaces it.
+    project_snapshot.clear()
+    _store(projectName="Second")
+    assert project_snapshot.advertised_fields()["project_name"] == "Second"
+
+    # And an upload that carries nothing erases it.
+    project_snapshot.clear()
+    assert project_snapshot.advertised_fields() == {}
+
+
+def test_a_staged_project_is_never_advertised():
+    # By the time anything is staged, the upload has already passed its point of
+    # no return and cleared the old project -- the program it described is being
+    # replaced. So the device advertises nothing at all until a build succeeds,
+    # which is the honest answer: naming the staged project would name one the
+    # device is not running and may never run.
+    _store(projectName="Running")
+    project_snapshot.stage(b"new-archive", _metadata(projectName="Building"))
+
+    assert project_snapshot.advertised_fields() == {}
+
+    # A failed build leaves it that way rather than resurrecting the old name.
+    project_snapshot.discard_staged()
+    assert project_snapshot.advertised_fields() == {}
+
+    # A successful one names the new project.
+    project_snapshot.stage(b"new-archive", _metadata(projectName="Built"))
+    assert project_snapshot.promote() is True
+    assert project_snapshot.advertised_fields()["project_name"] == "Built"
+
+
+def test_the_caller_cannot_mutate_the_cache_through_the_value_it_gets():
+    _store(projectName="Traffic Light")
+    first = project_snapshot.advertised_fields()
+    first["project_name"] = "tampered"
+    assert project_snapshot.advertised_fields()["project_name"] == "Traffic Light"

--- a/tests/pytest/restapi/test_project_snapshot.py
+++ b/tests/pytest/restapi/test_project_snapshot.py
@@ -1,0 +1,301 @@
+"""Behavioural tests for the stored source-project snapshot.
+
+The device stores an optional archive of the project a program was built from
+so an admin can retrieve it later. Two properties carry the whole design and
+are what these tests pin down:
+
+  * **The stored project never outlives the program it belongs to.** An upload
+    clears it, a successful build promotes the new one, and anything else
+    leaves the device with none. A device that advertised a project it was not
+    running would be worse than one that advertises nothing.
+
+  * **The runtime never opens the archive.** Everything it reports about the
+    stored project comes from metadata sent alongside the bytes, so these tests
+    deliberately stage archives that are not valid ZIPs at all.
+
+Retrieval is admin-only, and that role check is the *whole* of the access
+control -- the archive is not encrypted on disk -- so the refusal paths matter
+as much as the happy path.
+"""
+
+import base64
+import json
+
+import pytest
+from conftest import auth, create_user, token_for
+
+from webserver import project_snapshot
+
+
+@pytest.fixture(autouse=True)
+def clean_snapshot_store():
+    """No test may see another's stored project."""
+    project_snapshot.clear()
+    yield
+    project_snapshot.clear()
+
+
+def _metadata(**overrides):
+    record = {
+        "formatVersion": 1,
+        "projectName": "Traffic Light",
+        "editorVersion": "4.2.0",
+        "uploadedBy": "admin",
+        "timestamp": "2026-08-31T12:00:00Z",
+        "libraries": [{"name": "Motion", "version": "1.2.0", "hash": "abc123"}],
+    }
+    record.update(overrides)
+    return project_snapshot.normalize_metadata(record)
+
+
+def _store(blob=b"not-a-real-zip-on-purpose", **overrides):
+    """Stage and promote, i.e. the state after a successful build."""
+    project_snapshot.stage(blob, _metadata(**overrides))
+    assert project_snapshot.promote() is True
+
+
+# --- the stage / promote / discard cycle ---------------------------------
+
+
+def test_nothing_is_stored_on_a_fresh_device():
+    assert project_snapshot.has_snapshot() is False
+    assert project_snapshot.read_metadata() is None
+    assert project_snapshot.read_blob() is None
+
+
+def test_a_staged_snapshot_is_not_yet_readable():
+    # Until the build succeeds the device has no business claiming a project:
+    # the program it would describe does not exist yet.
+    project_snapshot.stage(b"payload", _metadata())
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_promote_makes_the_staged_snapshot_the_stored_one():
+    project_snapshot.stage(b"payload", _metadata())
+    assert project_snapshot.promote() is True
+    assert project_snapshot.read_blob() == b"payload"
+    assert project_snapshot.read_metadata()["projectName"] == "Traffic Light"
+
+
+def test_discard_leaves_the_device_with_nothing():
+    # The failed-build path. compile-clean.sh has already removed the program's
+    # .so by this point, so "no program, no stored project" is the honest state.
+    project_snapshot.stage(b"payload", _metadata())
+    project_snapshot.discard_staged()
+    assert project_snapshot.promote() is False
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_promote_without_anything_staged_is_a_no_op():
+    # An upload that sent no snapshot still reaches promote() when its build
+    # succeeds. It must not resurrect anything.
+    assert project_snapshot.promote() is False
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_clear_then_no_stage_erases_the_previous_project():
+    # This is exactly what an upload from an older editor does, and it is the
+    # point: the device stops advertising a project it is no longer running.
+    _store()
+    project_snapshot.clear()
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_a_second_upload_replaces_the_first():
+    _store(b"first", projectName="First")
+    project_snapshot.clear()
+    project_snapshot.stage(b"second", _metadata(projectName="Second"))
+    project_snapshot.promote()
+    assert project_snapshot.read_blob() == b"second"
+    assert project_snapshot.read_metadata()["projectName"] == "Second"
+
+
+def test_a_failed_build_after_a_successful_one_leaves_nothing():
+    # The dangerous middle state: an old snapshot must not survive an upload
+    # whose build failed, because the old PROGRAM did not survive it either.
+    _store(b"first", projectName="First")
+    project_snapshot.clear()
+    project_snapshot.stage(b"second", _metadata(projectName="Second"))
+    project_snapshot.discard_staged()
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_an_oversized_snapshot_is_refused():
+    oversized = b"x" * (project_snapshot.MAX_SNAPSHOT_BYTES + 1)
+    with pytest.raises(project_snapshot.SnapshotError):
+        project_snapshot.stage(oversized, _metadata())
+    assert project_snapshot.has_snapshot() is False
+
+
+def test_metadata_without_its_blob_describes_nothing():
+    # Defence against a half-written store: metadata alone is not a snapshot,
+    # because there is nothing to hand back.
+    _store()
+    project_snapshot._PROMOTED_BLOB.unlink()
+    assert project_snapshot.read_metadata() is None
+    assert project_snapshot.has_snapshot() is False
+
+
+# --- metadata normalisation ----------------------------------------------
+
+
+def test_metadata_requires_a_project_name():
+    with pytest.raises(project_snapshot.SnapshotError):
+        project_snapshot.normalize_metadata({"formatVersion": 1, "projectName": "  "})
+
+
+def test_metadata_requires_a_format_version():
+    with pytest.raises(project_snapshot.SnapshotError):
+        project_snapshot.normalize_metadata({"projectName": "P"})
+
+
+def test_metadata_rejects_a_non_object():
+    with pytest.raises(project_snapshot.SnapshotError):
+        project_snapshot.normalize_metadata(["not", "an", "object"])
+
+
+def test_unknown_metadata_keys_are_dropped():
+    # The device echoes this record to other clients, so the shape is the
+    # device's, not the uploader's.
+    record = project_snapshot.normalize_metadata(
+        {"formatVersion": 1, "projectName": "P", "somethingElse": "ignored"}
+    )
+    assert "somethingElse" not in record
+
+
+def test_control_characters_are_stripped_from_metadata_strings():
+    # These values land in a JSON discovery reply and in client UI; a newline in
+    # a project name should not be able to reshape either.
+    record = project_snapshot.normalize_metadata(
+        {"formatVersion": 1, "projectName": "Line\nBreak\tProject"}
+    )
+    assert "\n" not in record["projectName"]
+    assert "\t" not in record["projectName"]
+
+
+def test_malformed_library_entries_are_dropped_not_fatal():
+    record = project_snapshot.normalize_metadata(
+        {
+            "formatVersion": 1,
+            "projectName": "P",
+            "libraries": ["not-an-object", {"version": "1.0"}, {"name": "Real"}],
+        }
+    )
+    assert [lib["name"] for lib in record["libraries"]] == ["Real"]
+
+
+# --- discovery advertisement ---------------------------------------------
+
+
+def test_discovery_advertises_nothing_when_no_project_is_stored():
+    # Absence of the keys is how a client tells there is nothing to retrieve;
+    # there is deliberately no separate boolean.
+    assert project_snapshot.advertised_fields() == {}
+
+
+def test_discovery_advertises_only_name_and_timestamp():
+    _store()
+    fields = project_snapshot.advertised_fields()
+    assert fields == {
+        "project_name": "Traffic Light",
+        "project_timestamp": "2026-08-31T12:00:00Z",
+    }
+
+
+# --- GET /api/project-snapshot/info --------------------------------------
+
+
+def test_info_requires_authentication(client):
+    assert client.get("/api/project-snapshot/info").status_code == 401
+
+
+def test_info_reports_absence_on_a_fresh_device(client, admin_token):
+    body = client.get("/api/project-snapshot/info", headers=auth(admin_token)).get_json()
+    assert body == {"present": False}
+
+
+def test_info_reports_the_stored_project(client, admin_token):
+    _store(b"payload")
+    body = client.get("/api/project-snapshot/info", headers=auth(admin_token)).get_json()
+    assert body["present"] is True
+    assert body["projectName"] == "Traffic Light"
+    assert body["editorVersion"] == "4.2.0"
+    assert body["uploadedBy"] == "admin"
+    assert body["sizeBytes"] == len(b"payload")
+    assert body["libraries"][0]["name"] == "Motion"
+
+
+def test_info_is_open_to_non_admins(client, admin_token):
+    # Deciding whether to OFFER retrieval is not privileged; retrieving is.
+    _store()
+    create_user(client, "operator", "operator-pass", token=admin_token, role="user")
+    operator = token_for(client, "operator", "operator-pass")
+    resp = client.get("/api/project-snapshot/info", headers=auth(operator))
+    assert resp.status_code == 200
+    assert resp.get_json()["present"] is True
+
+
+# --- GET /api/project-snapshot -------------------------------------------
+
+
+def test_retrieval_requires_authentication(client):
+    assert client.get("/api/project-snapshot").status_code == 401
+
+
+def test_retrieval_is_refused_to_non_admins(client, admin_token):
+    # The stored project is not encrypted on the device, so this role check is
+    # the entire access control. It is not a second layer behind one.
+    _store()
+    create_user(client, "operator", "operator-pass", token=admin_token, role="user")
+    operator = token_for(client, "operator", "operator-pass")
+    assert client.get("/api/project-snapshot", headers=auth(operator)).status_code == 403
+
+
+def test_retrieval_returns_the_stored_archive_verbatim(client, admin_token):
+    blob = b"PK\x03\x04 pretend archive \x00\xff"
+    _store(blob)
+    body = client.get("/api/project-snapshot", headers=auth(admin_token)).get_json()
+    assert base64.b64decode(body["contentBase64"]) == blob
+    assert body["projectName"] == "Traffic Light"
+    assert body["filename"] == "project.zip"
+
+
+def test_retrieval_404s_when_nothing_is_stored(client, admin_token):
+    assert client.get("/api/project-snapshot", headers=auth(admin_token)).status_code == 404
+
+
+def test_retrieval_404s_while_a_snapshot_is_only_staged(client, admin_token):
+    # Mid-build: the program is not in place yet, so neither is the project.
+    project_snapshot.stage(b"payload", _metadata())
+    assert client.get("/api/project-snapshot", headers=auth(admin_token)).status_code == 404
+
+
+def test_the_runtime_never_parses_the_archive(client, admin_token):
+    # A blob that is definitively not a ZIP round-trips untouched. If this ever
+    # fails, something started inspecting the archive and the format is no
+    # longer free to change without touching the device.
+    blob = b"\x00\x01\x02 definitely not a zip \xfe\xff"
+    _store(blob)
+    body = client.get("/api/project-snapshot", headers=auth(admin_token)).get_json()
+    assert base64.b64decode(body["contentBase64"]) == blob
+
+
+def test_a_new_admin_can_retrieve_a_project_stored_before_the_account_existed(client, admin_token):
+    # The snapshot deliberately survives changes to the user list, including a
+    # credentials reset that wipes the database: retrieval is gated on holding
+    # admin credentials at request time, not on who uploaded.
+    _store()
+    create_user(client, "second-admin", "second-pass", token=admin_token, role="admin")
+    second = token_for(client, "second-admin", "second-pass")
+    resp = client.get("/api/project-snapshot", headers=auth(second))
+    assert resp.status_code == 200
+    assert resp.get_json()["projectName"] == "Traffic Light"
+
+
+# --- capabilities ---------------------------------------------------------
+
+
+def test_capabilities_advertises_snapshot_support(client):
+    # Unauthenticated on purpose: a client decides whether to build and send a
+    # snapshot before it has logged in to the device.
+    assert client.get("/api/capabilities").get_json()["projectSnapshot"] is True

--- a/tests/pytest/restapi/test_project_snapshot.py
+++ b/tests/pytest/restapi/test_project_snapshot.py
@@ -101,6 +101,18 @@ def test_clear_then_no_stage_erases_the_previous_project():
     assert project_snapshot.has_snapshot() is False
 
 
+def test_a_stranded_staged_snapshot_is_never_promoted_by_a_later_build():
+    # If an upload dies after staging but before the compile thread starts
+    # (a failed extract, say), nothing discards what it staged. The next
+    # upload's clear() has to be what removes it -- otherwise that build would
+    # promote a snapshot belonging to an upload that never landed, and the
+    # device would advertise a project it is definitely not running.
+    project_snapshot.stage(b"stranded", _metadata(projectName="Never Landed"))
+    project_snapshot.clear()  # the next upload
+    assert project_snapshot.promote() is False
+    assert project_snapshot.has_snapshot() is False
+
+
 def test_a_second_upload_replaces_the_first():
     _store(b"first", projectName="First")
     project_snapshot.clear()

--- a/tests/pytest/restapi/test_repair_missing_admin.py
+++ b/tests/pytest/restapi/test_repair_missing_admin.py
@@ -1,0 +1,167 @@
+"""A device left with accounts but no administrator.
+
+That state is a dead end rather than an inconvenience: once any user exists,
+``create-user`` refuses a non-admin caller and ``update-user`` refuses a role
+change from one, so no sequence of API calls produces an admin. Everything
+admin-gated stays unreachable, and nothing surfaces it until someone tries.
+
+Devices reach it by upgrading through an early build of the roles feature,
+whose ``role`` column was nullable with no default. ``apply_user_schema_
+migrations`` does not cover it -- that only runs when the column is ABSENT, so
+a database that already has one keeps whatever it holds.
+
+The repair promotes a single account and refuses to choose among several. Both
+halves matter: the first rescues the devices that exist, and the second keeps
+the runtime from silently handing administrator rights to whichever account
+happens to sort first.
+"""
+
+from conftest import auth, create_user, token_for
+from sqlalchemy import text as sa_text
+
+from webserver.restapi import ADMIN_ROLE, USER_ROLE, User, admin_count, db, repair_missing_admin
+
+
+def _add_user(username, role):
+    """Insert an account directly, bypassing the role rules the API enforces.
+
+    The states under test cannot be produced through the API at all -- that is
+    the whole problem -- so they have to be built underneath it.
+    """
+    user = User(username=username, role=role)
+    user.set_password("pass-for-" + username)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _roles():
+    return {user.username: user.role for user in User.query.all()}
+
+
+# --- the repair ----------------------------------------------------------
+
+
+def test_a_lone_non_admin_account_is_promoted(app):
+    _add_user("op", USER_ROLE)
+    assert repair_missing_admin() is True
+    assert _roles() == {"op": ADMIN_ROLE}
+
+
+def test_a_null_role_counts_as_no_admin_rather_than_crashing(app):
+    # Rebuilt as the schema an affected device actually carries, copied from
+    # the hardware unit this was found on:
+    #
+    #     role VARCHAR(20)      -- nullable, no default
+    #
+    # The current model declares NOT NULL DEFAULT 'admin', so a NULL role
+    # cannot be created through it or even inserted into the table it builds.
+    # Reproducing the old shape is the only way to check the repair copes with
+    # what is out there rather than with what we would write today.
+    db.session.execute(sa_text("DROP TABLE users"))
+    db.session.execute(
+        sa_text(
+            "CREATE TABLE users ("
+            " id INTEGER NOT NULL,"
+            " username TEXT NOT NULL,"
+            " password_hash TEXT NOT NULL,"
+            " role VARCHAR(20),"
+            " PRIMARY KEY (id),"
+            " UNIQUE (username))"
+        )
+    )
+    db.session.execute(
+        sa_text("INSERT INTO users (username, password_hash, role) VALUES ('op', 'x', NULL)")
+    )
+    db.session.commit()
+
+    assert admin_count() == 0
+    assert repair_missing_admin() is True
+    assert _roles() == {"op": ADMIN_ROLE}
+
+
+def test_the_repair_is_a_no_op_on_every_later_boot(app):
+    _add_user("op", USER_ROLE)
+    assert repair_missing_admin() is True
+    # Second boot: an admin now exists, so there is nothing to do. This has to
+    # be a real no-op, not merely idempotent by luck.
+    assert repair_missing_admin() is False
+    assert _roles() == {"op": ADMIN_ROLE}
+
+
+def test_several_accounts_with_no_admin_are_left_alone(app):
+    # The runtime has no basis for choosing which account becomes the
+    # administrator, so it refuses rather than picking one silently.
+    _add_user("alice", USER_ROLE)
+    _add_user("bob", USER_ROLE)
+    assert repair_missing_admin() is False
+    assert _roles() == {"alice": USER_ROLE, "bob": USER_ROLE}
+
+
+def test_several_accounts_with_no_admin_are_reported(app, caplog):
+    # Nothing else will ever surface this state -- an operator only finds it by
+    # hitting a 403 on something that should have worked.
+    _add_user("alice", USER_ROLE)
+    _add_user("bob", USER_ROLE)
+    with caplog.at_level("ERROR"):
+        repair_missing_admin()
+    logged = caplog.text
+    assert "alice" in logged and "bob" in logged
+
+
+def test_an_existing_admin_is_untouched(app):
+    _add_user("admin", ADMIN_ROLE)
+    _add_user("op", USER_ROLE)
+    assert repair_missing_admin() is False
+    assert _roles() == {"admin": ADMIN_ROLE, "op": USER_ROLE}
+
+
+def test_a_device_with_no_accounts_is_left_to_bootstrap(app):
+    # A fresh device is not broken, it is empty. The bootstrap path already
+    # makes the first account an admin.
+    assert repair_missing_admin() is False
+    assert User.query.count() == 0
+
+
+def test_bootstrap_still_produces_an_admin_after_the_repair_runs(client):
+    assert repair_missing_admin() is False
+    resp = create_user(client, "first", "first-pass")
+    assert resp.status_code == 201
+    assert resp.get_json()["role"] == ADMIN_ROLE
+
+
+# --- what the repair actually restores -----------------------------------
+
+
+def test_the_promoted_account_can_use_admin_only_endpoints(client, app):
+    # The point of the repair, end to end: before it, this account cannot reach
+    # anything admin-gated and cannot be granted access by any API call.
+    _add_user("op", USER_ROLE)
+    token = token_for(client, "op", "pass-for-op")
+    assert client.get("/api/project-snapshot", headers=auth(token)).status_code == 403
+
+    repair_missing_admin()
+
+    # A fresh token, because the role is read from the database per request but
+    # the identity was established before the promotion.
+    token = token_for(client, "op", "pass-for-op")
+    assert client.get("/api/whoami", headers=auth(token)).get_json()["role"] == ADMIN_ROLE
+    # 404 rather than 403: reachable now, with nothing stored to hand back.
+    assert client.get("/api/project-snapshot", headers=auth(token)).status_code == 404
+
+
+def test_without_the_repair_there_is_no_way_back(client, app):
+    # Documents why this cannot be left to the operator: with no admin, neither
+    # of the two endpoints that could create one will act.
+    _add_user("op", USER_ROLE)
+    token = token_for(client, "op", "pass-for-op")
+
+    created = create_user(client, "new-admin", "pw", token=token, role=ADMIN_ROLE)
+    assert created.status_code == 403
+
+    promoted = client.put(
+        f"/api/update-user/{User.query.filter_by(username='op').one().id}",
+        json={"role": ADMIN_ROLE},
+        headers=auth(token),
+    )
+    assert promoted.status_code == 403

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -52,6 +52,17 @@ logger, _ = get_logger("logger", use_buffer=True)
 
 app = flask.Flask(__name__)
 app.secret_key = str(os.urandom(16))
+
+# A backstop at the HTTP layer, under everything the routes do.
+#
+# Individual handlers check their own parts, but those checks run after Werkzeug
+# has already parsed (and spooled to disk) the request. This bounds the whole
+# body first, so an oversized upload is refused as 413 before any of it is
+# stored. Sized to hold the largest legitimate request -- a program zip and a
+# project snapshot together -- plus room for the multipart framing.
+app.config["MAX_CONTENT_LENGTH"] = (
+    MAX_FILE_SIZE + project_snapshot.MAX_SNAPSHOT_BYTES + (8 * 1024 * 1024)
+)
 login_manager = flask_login.LoginManager()
 login_manager.init_app(app)
 
@@ -274,10 +285,35 @@ def stage_project_snapshot() -> str:
     except project_snapshot.SnapshotError as e:
         return f"Snapshot ignored: {e}"
 
+    # Bounded read, before the bytes exist rather than after.
+    #
+    # `stage()` also enforces the cap, but only once the whole part is already
+    # in memory -- and this route is authenticated without an admin gate, so any
+    # account on the device could post an arbitrarily large `snapshot` field and
+    # have it spooled to disk and then pulled into RAM before anything refused
+    # it. On the hardware this runtime targets that is a disk-fill followed by
+    # an OOM.
+    #
+    # `content_length` on a multipart part is client-supplied and often absent,
+    # so it is a fast path and not the guard. Reading one byte past the cap and
+    # stopping is what actually bounds this, whatever the client claimed.
+    declared = snapshot_file.content_length
+    if declared and declared > project_snapshot.MAX_SNAPSHOT_BYTES:
+        return (
+            f"Snapshot ignored: archive is too large "
+            f"({declared} bytes, limit {project_snapshot.MAX_SNAPSHOT_BYTES})"
+        )
+
     try:
-        blob = snapshot_file.read()
+        blob = snapshot_file.read(project_snapshot.MAX_SNAPSHOT_BYTES + 1)
     except (OSError, IOError) as e:
         return f"Snapshot ignored: could not read the uploaded archive ({e})"
+
+    if len(blob) > project_snapshot.MAX_SNAPSHOT_BYTES:
+        return (
+            f"Snapshot ignored: archive is too large "
+            f"(limit {project_snapshot.MAX_SNAPSHOT_BYTES} bytes)"
+        )
 
     try:
         project_snapshot.stage(blob, metadata)

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -43,6 +43,7 @@ from webserver.restapi import (
     db,
     register_callback_get,
     register_callback_post,
+    repair_missing_admin,
     restapi_bp,
 )
 from webserver.runtimemanager import RuntimeManager
@@ -457,6 +458,13 @@ def run_https():
             # users.role column in place; no-op once present).
             apply_user_schema_migrations()
             db.session.commit()
+            # Rescue a device left with accounts but no admin. Unlike the
+            # schema migration above this is a DATA repair, and it has to run
+            # separately: the migration only fires when the role column is
+            # missing, so a database that already has one keeps whatever values
+            # it holds -- including none of them being 'admin'. Without an
+            # admin there is no API path back to having one.
+            repair_missing_admin()
             # logger.info("Database tables created successfully.")
         except Exception:
             # logger.error("Error creating database tables: %s", e)

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -334,7 +334,6 @@ def handle_upload_file(data: dict) -> dict:
         # client keep working, and the device stops advertising a project it
         # is no longer running.
         project_snapshot.clear()
-        snapshot_error = stage_project_snapshot()
 
         if os.path.exists(extract_dir):
             shutil.rmtree(extract_dir)
@@ -362,6 +361,16 @@ def handle_upload_file(data: dict) -> dict:
         # ccache contents before invoking compile.sh. Older editors
         # don't pass this flag, so behaviour for them is unchanged.
         clean_build = flask.request.args.get("clean") == "1"
+
+        # Stage the snapshot only once the program itself is safely in place.
+        # run_compile's `finally` is what promotes or discards a staged
+        # snapshot, so staging before the extract would leave one stranded if
+        # the extract threw -- the compile thread never starts, nothing
+        # discards it, and the NEXT successful build would promote a snapshot
+        # belonging to an upload that never landed. The clear() above has
+        # already erased the old one either way, which is correct: the program
+        # it described is gone.
+        snapshot_error = stage_project_snapshot()
 
         # Start compilation in a separate thread
         build_state.status = BuildStatus.COMPILING

--- a/webserver/app.py
+++ b/webserver/app.py
@@ -21,6 +21,7 @@ from typing import Callable, Final, Optional
 import flask
 import flask_login
 
+from webserver import project_snapshot
 from webserver.credentials import CertGen
 from webserver.debug_websocket import init_debug_websocket
 from webserver.discovery.discovery_routes import discovery_bp
@@ -30,10 +31,10 @@ from webserver.plcapp_management import (
     MAX_FILE_SIZE,
     BuildStatus,
     analyze_zip,
+    apply_vpp_plugin_conf,
     build_state,
     run_compile,
     safe_extract,
-    apply_vpp_plugin_conf,
     update_plugin_configurations,
 )
 from webserver.restapi import (
@@ -243,6 +244,48 @@ def restapi_callback_get(argument: str, data: dict) -> dict:
     return {"error": "Unknown argument"}
 
 
+def stage_project_snapshot() -> str:
+    """Stage the optional source-project snapshot that rides along with an upload.
+
+    Returns an empty string when there was nothing to store or it was stored,
+    and a human-readable reason otherwise. Never raises: the snapshot is the
+    optional half of the request and must not be able to fail a program upload.
+
+    The two fields are deliberately separate from ``program.zip``. Inside it
+    they would run through ``analyze_zip`` and be extracted into
+    ``core/generated``, where the next upload would wipe them and the compiler
+    would try to build them. The metadata is separate from the archive for the
+    same reason in reverse: the runtime never opens the archive, so anything it
+    needs to say about the stored project has to arrive already parsed.
+    """
+    snapshot_file = flask.request.files.get("snapshot")
+    if snapshot_file is None:
+        return ""
+
+    raw_metadata = flask.request.form.get("snapshot_metadata")
+    if not raw_metadata:
+        return "Snapshot ignored: the upload carried an archive but no snapshot_metadata"
+
+    try:
+        metadata = project_snapshot.normalize_metadata(json.loads(raw_metadata))
+    except json.JSONDecodeError as e:
+        return f"Snapshot ignored: snapshot_metadata is not valid JSON ({e})"
+    except project_snapshot.SnapshotError as e:
+        return f"Snapshot ignored: {e}"
+
+    try:
+        blob = snapshot_file.read()
+    except (OSError, IOError) as e:
+        return f"Snapshot ignored: could not read the uploaded archive ({e})"
+
+    try:
+        project_snapshot.stage(blob, metadata)
+    except project_snapshot.SnapshotError as e:
+        return f"Snapshot ignored: {e}"
+
+    return ""
+
+
 def handle_upload_file(data: dict) -> dict:
     if build_state.status == BuildStatus.COMPILING:
         return {
@@ -279,6 +322,20 @@ def handle_upload_file(data: dict) -> dict:
             }
 
         extract_dir = "core/generated"
+
+        # Point of no return: past here the program on the device is being
+        # replaced, so the stored project snapshot must go with it. Clearing
+        # here rather than on arrival means a rejected upload (bad zip, too
+        # large, runtime busy) leaves the previous program AND its snapshot
+        # untouched, which is the pair that is actually still true.
+        #
+        # An upload carrying no snapshot therefore erases the stored one --
+        # that is the point. Older editors, openplc-cli and any third-party
+        # client keep working, and the device stops advertising a project it
+        # is no longer running.
+        project_snapshot.clear()
+        snapshot_error = stage_project_snapshot()
+
         if os.path.exists(extract_dir):
             shutil.rmtree(extract_dir)
 
@@ -318,7 +375,15 @@ def handle_upload_file(data: dict) -> dict:
 
         task_compile.start()
 
-        return {"UploadFileFail": "", "CompilationStatus": build_state.status.name}
+        # The program upload itself succeeded. A snapshot that could not be
+        # stored is reported alongside rather than as a failure: the device is
+        # running the new program either way, and failing the upload over the
+        # optional half of it would be worse than losing retrievability.
+        return {
+            "UploadFileFail": "",
+            "CompilationStatus": build_state.status.name,
+            "ProjectSnapshotWarning": snapshot_error,
+        }
 
     except (OSError, IOError) as e:
         build_state.status = BuildStatus.FAILED

--- a/webserver/discovery/network_discovery.py
+++ b/webserver/discovery/network_discovery.py
@@ -9,7 +9,9 @@ The protocol is intentionally tiny and stateless:
 
     Request   : "OPENPLC_DISCOVER_V1"          (UTF-8, exact)
     Response  : JSON with {service, protocol_version, runtime_version,
-                           hostname, api_port}
+                           hostname, api_port} plus {project_name,
+                           project_timestamp} when a source project is
+                           stored on the device
 
 Only the magic string is accepted; anything else is dropped silently.
 Replies are unicast to the source address of the request, which is
@@ -26,6 +28,7 @@ import threading
 import time
 from typing import Optional
 
+from webserver import project_snapshot
 from webserver.logger import get_logger
 from webserver.version import RUNTIME_VERSION
 
@@ -136,6 +139,13 @@ class NetworkDiscoveryResponder:
                 ip: ts for ip, ts in self._last_seen.items() if ts >= cutoff
             }
 
+        # Name and timestamp of the stored source project, when there is one.
+        # This is what lets a client populate its "Retrieve Project from PLC"
+        # picker without logging in to every device on the LAN first. Absent
+        # keys mean no stored project, so there is no separate flag.
+        #
+        # Deliberately just these two: they are exactly what the picker shows.
+        # Everything else about the stored project needs authentication.
         payload = json.dumps(
             {
                 "service": "openplc-runtime",
@@ -143,6 +153,7 @@ class NetworkDiscoveryResponder:
                 "runtime_version": RUNTIME_VERSION,
                 "hostname": socket.gethostname(),
                 "api_port": API_PORT,
+                **project_snapshot.advertised_fields(),
             },
             separators=(",", ":"),
         ).encode("utf-8")

--- a/webserver/plcapp_management.py
+++ b/webserver/plcapp_management.py
@@ -1,17 +1,18 @@
-from dataclasses import dataclass, field
-from enum import Enum, auto
+import glob
 import os
 import shutil
-import time
-import zipfile
 import subprocess
 import threading
-import glob
+import time
+import zipfile
+from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import Final
 
+from webserver import project_snapshot
+from webserver.logger import LogParser, get_logger
+from webserver.plugin_config_model import PluginConfig, PluginsConfiguration, PluginType
 from webserver.runtimemanager import RuntimeManager
-from webserver.logger import get_logger, LogParser
-from webserver.plugin_config_model import PluginsConfiguration, PluginConfig, PluginType
 from webserver.vpp_license_debug import derive_license_path, is_inside_root
 
 logger, _ = get_logger("runtime", use_buffer=True)
@@ -619,3 +620,21 @@ def run_compile(runtime_manager: RuntimeManager, cwd: str = "core/generated", cl
         build_state.log(f"[ERROR] Compile orchestrator crashed: {e}\n")
         build_state.status = BuildStatus.FAILED
         build_state.exit_code = -1
+    finally:
+        # The stored project snapshot follows the program exactly. A snapshot
+        # staged by the upload becomes the stored one only once the build has
+        # actually produced a program; any other outcome discards it, and the
+        # upload already cleared whatever was stored before.
+        #
+        # In a `finally` so the outer crash guard above cannot leave a staged
+        # snapshot behind to be promoted by the NEXT build. Discarding is the
+        # honest end state either way: a failed build leaves the device with no
+        # program at all, because compile-clean.sh removes libplc_*.so before it
+        # has a replacement to move into place.
+        try:
+            if build_state.status == BuildStatus.SUCCESS:
+                project_snapshot.promote()
+            else:
+                project_snapshot.discard_staged()
+        except Exception as e:  # never let snapshot bookkeeping mask a build result
+            build_state.log(f"[WARNING] Project snapshot bookkeeping failed: {e}\n")

--- a/webserver/project_snapshot.py
+++ b/webserver/project_snapshot.py
@@ -38,7 +38,7 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Final, Optional
+from typing import Any, Final, Iterator, Optional
 
 from webserver.config import PERSISTENT_DATA_DIR
 from webserver.logger import get_logger
@@ -51,6 +51,17 @@ _PROMOTED_BLOB: Final[Path] = SNAPSHOT_DIR / "project.zip"
 _PROMOTED_META: Final[Path] = SNAPSHOT_DIR / "project.json"
 _STAGED_BLOB: Final[Path] = SNAPSHOT_DIR / "staged.zip"
 _STAGED_META: Final[Path] = SNAPSHOT_DIR / "staged.json"
+
+# What the discovery responder advertises, kept in memory.
+#
+# `advertised_fields()` is called on every UDP probe, from the unauthenticated
+# responder, and read the metadata file each time -- two stats and a JSON parse
+# per packet. The per-source rate limit means that was never a real DoS, but a
+# spoofed-source flood still turned each packet into disk I/O for no reason.
+# Only the four functions below write the store, so those are the only places
+# this has to be dropped. `None` means "not computed yet", which is distinct
+# from the empty dict meaning "nothing stored".
+_advertised_cache: Optional[dict] = None
 
 # Cap for the snapshot field.  Deliberately its own constant and much larger
 # than the program-zip limits in plcapp_management: those guard an archive that
@@ -82,6 +93,10 @@ def _clean_string(value: Any) -> str:
     reply and in client UI; a newline in a project name should not be able to
     reshape either.
     """
+    # `isprintable()` is False for tabs and newlines (which have no business in
+    # a project name) and True for non-ASCII printables, so accents and
+    # non-Latin scripts are kept deliberately -- it reads like an ASCII filter
+    # at a glance and is not one.
     if not isinstance(value, str):
         return ""
     cleaned = "".join(ch for ch in value if ch.isprintable())
@@ -138,6 +153,8 @@ def clear() -> None:
     Called at the start of every upload.  A missing directory is the normal
     state on a device that has never stored one, not an error.
     """
+    global _advertised_cache
+    _advertised_cache = None
     try:
         shutil.rmtree(SNAPSHOT_DIR)
     except FileNotFoundError:
@@ -151,7 +168,14 @@ def stage(blob: bytes, metadata: dict) -> None:
 
     Clearing first is what makes an upload carrying no snapshot erase the old
     one -- the caller simply does not follow with a stage().
+
+    Clears the store first. On the upload path the caller has already done that
+    at its point of no return, so this is usually a no-op -- but `stage()` owns
+    the invariant that nothing older survives beside what it writes, rather than
+    inheriting it from whoever called.
     """
+    global _advertised_cache
+    _advertised_cache = None
     if len(blob) > MAX_SNAPSHOT_BYTES:
         raise SnapshotError(
             f"Project snapshot is too large " f"({len(blob)} bytes, limit {MAX_SNAPSHOT_BYTES})"
@@ -176,6 +200,8 @@ def stage(blob: bytes, metadata: dict) -> None:
 
 def promote() -> bool:
     """Make the staged snapshot the stored one.  Returns True if one was staged."""
+    global _advertised_cache
+    _advertised_cache = None
     if not (_STAGED_BLOB.exists() and _STAGED_META.exists()):
         return False
     try:
@@ -191,6 +217,8 @@ def promote() -> bool:
 
 def discard_staged() -> None:
     """Drop a staged snapshot after a failed build."""
+    global _advertised_cache
+    _advertised_cache = None
     for path in (_STAGED_BLOB, _STAGED_META):
         try:
             path.unlink()
@@ -205,6 +233,20 @@ def read_metadata() -> Optional[dict]:
     try:
         record = json.loads(_PROMOTED_META.read_text(encoding="utf-8"))
     except FileNotFoundError:
+        # `promote()` moves the blob and the metadata in two steps, so a power
+        # cut between them can leave a blob with no metadata. Reporting "nothing
+        # stored" is the right answer -- a blob we cannot describe is not
+        # retrievable -- but doing it silently leaves a device that was storing
+        # a project now saying it is not, with nothing to explain why on a
+        # machine you cannot attach a debugger to.
+        if _PROMOTED_BLOB.exists():
+            logger.warning(
+                "A stored project archive exists with no metadata beside it "
+                "(%s). It is being reported as no stored project; the next "
+                "upload will clear it. This is what an interrupted promote "
+                "leaves behind.",
+                _PROMOTED_BLOB,
+            )
         return None
     except (OSError, ValueError) as exc:
         logger.warning("Stored project snapshot metadata is unreadable: %s", exc)
@@ -215,6 +257,27 @@ def read_metadata() -> Optional[dict]:
     if not _PROMOTED_BLOB.exists():
         return None
     return record
+
+
+def blob_path() -> Path:
+    """Where the stored archive lives, for callers that stream it themselves."""
+    return _PROMOTED_BLOB
+
+
+def iter_blob(chunk_size: int) -> Iterator[bytes]:
+    """The stored archive in chunks.
+
+    For the retrieval path, which encodes straight into the response rather than
+    holding the whole archive and its base64 expansion in memory at once. Raises
+    OSError like any other read; the caller decides what a partial read means,
+    because by then it may already have sent a response header.
+    """
+    with _PROMOTED_BLOB.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                return
+            yield chunk
 
 
 def read_blob() -> Optional[bytes]:
@@ -239,10 +302,18 @@ def advertised_fields() -> dict:
     without a login per device, and nothing beyond what the picker shows.
     Absent keys mean no stored project, so no separate flag is needed.
     """
+    global _advertised_cache
+    if _advertised_cache is not None:
+        return dict(_advertised_cache)
+
     record = read_metadata()
-    if record is None:
-        return {}
-    return {
-        "project_name": record.get("projectName", ""),
-        "project_timestamp": record.get("timestamp", ""),
-    }
+    fields = (
+        {}
+        if record is None
+        else {
+            "project_name": record.get("projectName", ""),
+            "project_timestamp": record.get("timestamp", ""),
+        }
+    )
+    _advertised_cache = fields
+    return dict(fields)

--- a/webserver/project_snapshot.py
+++ b/webserver/project_snapshot.py
@@ -1,0 +1,248 @@
+"""Storage for the source project snapshot a client sends with an upload.
+
+The editor compiles a project and uploads only the build artifacts, so nothing
+on the device has ever recorded the project the artifacts came from.  This
+module stores an optional snapshot of that project so an admin can retrieve it
+later ("Retrieve Project from PLC").
+
+Two rules shape everything here:
+
+  * **The blob is opaque.**  The runtime never opens the archive, never parses
+    it, never validates its contents.  Everything the device needs to *say*
+    about the stored project arrives as separate metadata alongside the bytes.
+    Keeping this property is what keeps the device side small: the archive
+    format can change entirely without touching the runtime.
+
+  * **The stored project must match the running program.**  An upload clears
+    the snapshot first and only promotes the new one once the build succeeds.
+    A device therefore never advertises a project it is not running, and an
+    upload from a client that sends no snapshot (an older editor, the CLI, any
+    third party) correctly leaves the device with none.
+
+The staged/promoted split exists for the second rule.  ``stage()`` runs when
+the upload arrives, ``promote()`` when the build succeeds, and
+``discard_staged()`` when it fails -- which matches what the build itself does
+to the program: ``compile-clean.sh`` removes ``libplc_*.so`` before it has a
+replacement, so a failed build leaves no program, and "no program, no stored
+project" is the accurate state.
+
+Note the snapshot deliberately survives a credentials reset (``config.py``
+deletes ``restapi.db`` when ``.env`` is regenerated).  Retrieval is gated on
+holding admin credentials at the time of the request, so a freshly created
+admin set is expected to be able to retrieve the stored project.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Final, Optional
+
+from webserver.config import PERSISTENT_DATA_DIR
+from webserver.logger import get_logger
+
+logger, _ = get_logger(__name__)
+
+SNAPSHOT_DIR: Final[Path] = PERSISTENT_DATA_DIR / "project_snapshot"
+
+_PROMOTED_BLOB: Final[Path] = SNAPSHOT_DIR / "project.zip"
+_PROMOTED_META: Final[Path] = SNAPSHOT_DIR / "project.json"
+_STAGED_BLOB: Final[Path] = SNAPSHOT_DIR / "staged.zip"
+_STAGED_META: Final[Path] = SNAPSHOT_DIR / "staged.json"
+
+# Cap for the snapshot field.  Deliberately its own constant and much larger
+# than the program-zip limits in plcapp_management: those guard an archive that
+# gets extracted and compiled, while this one is stored untouched, and a real
+# project carrying its bundled libraries is a great deal bigger than the
+# generated sources.
+MAX_SNAPSHOT_BYTES: Final[int] = 100 * 1024 * 1024
+
+# Bounds on the metadata the device will repeat back to clients.  This is not
+# security -- an authenticated client could write anything -- it just stops a
+# malformed or hostile upload from parking unbounded junk in the discovery
+# payload and the info endpoint.
+_MAX_STRING_LEN: Final[int] = 512
+_MAX_LIBRARIES: Final[int] = 256
+
+
+class SnapshotError(ValueError):
+    """Raised for a snapshot the runtime will not store."""
+
+
+def _ensure_dir() -> None:
+    SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _clean_string(value: Any) -> str:
+    """One metadata string, truncated and stripped of control characters.
+
+    Control characters matter because these values land in a JSON discovery
+    reply and in client UI; a newline in a project name should not be able to
+    reshape either.
+    """
+    if not isinstance(value, str):
+        return ""
+    cleaned = "".join(ch for ch in value if ch.isprintable())
+    return cleaned.strip()[:_MAX_STRING_LEN]
+
+
+def normalize_metadata(raw: Any) -> dict:
+    """Coerce client-supplied metadata into the record the device will serve.
+
+    Unknown keys are dropped rather than stored: everything here is echoed back
+    to other clients, so the shape is the device's, not the uploader's.
+    """
+    if not isinstance(raw, dict):
+        raise SnapshotError("Snapshot metadata must be a JSON object")
+
+    libraries = []
+    raw_libraries = raw.get("libraries")
+    if isinstance(raw_libraries, list):
+        for entry in raw_libraries[:_MAX_LIBRARIES]:
+            if not isinstance(entry, dict):
+                continue
+            name = _clean_string(entry.get("name"))
+            if not name:
+                continue
+            libraries.append(
+                {
+                    "name": name,
+                    "version": _clean_string(entry.get("version")),
+                    "hash": _clean_string(entry.get("hash")),
+                }
+            )
+
+    format_version = raw.get("formatVersion")
+    if not isinstance(format_version, int) or format_version < 1:
+        raise SnapshotError("Snapshot metadata needs an integer formatVersion of 1 or more")
+
+    project_name = _clean_string(raw.get("projectName"))
+    if not project_name:
+        raise SnapshotError("Snapshot metadata needs a projectName")
+
+    return {
+        "formatVersion": format_version,
+        "projectName": project_name,
+        "editorVersion": _clean_string(raw.get("editorVersion")),
+        "uploadedBy": _clean_string(raw.get("uploadedBy")),
+        "timestamp": _clean_string(raw.get("timestamp")),
+        "libraries": libraries,
+    }
+
+
+def clear() -> None:
+    """Remove the stored snapshot and anything staged.
+
+    Called at the start of every upload.  A missing directory is the normal
+    state on a device that has never stored one, not an error.
+    """
+    try:
+        shutil.rmtree(SNAPSHOT_DIR)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("Could not clear the stored project snapshot: %s", exc)
+
+
+def stage(blob: bytes, metadata: dict) -> None:
+    """Replace the stored snapshot with one awaiting a successful build.
+
+    Clearing first is what makes an upload carrying no snapshot erase the old
+    one -- the caller simply does not follow with a stage().
+    """
+    if len(blob) > MAX_SNAPSHOT_BYTES:
+        raise SnapshotError(
+            f"Project snapshot is too large " f"({len(blob)} bytes, limit {MAX_SNAPSHOT_BYTES})"
+        )
+
+    record = dict(metadata)
+    record["sizeBytes"] = len(blob)
+
+    clear()
+    _ensure_dir()
+    try:
+        _STAGED_BLOB.write_bytes(blob)
+        _STAGED_META.write_text(json.dumps(record), encoding="utf-8")
+    except OSError as exc:
+        # Leave nothing half-written: a staged blob without its metadata would
+        # be promoted into a snapshot the info endpoint cannot describe.
+        clear()
+        raise SnapshotError(f"Could not store the project snapshot: {exc}") from exc
+
+    logger.info("Project snapshot staged (%d bytes)", len(blob))
+
+
+def promote() -> bool:
+    """Make the staged snapshot the stored one.  Returns True if one was staged."""
+    if not (_STAGED_BLOB.exists() and _STAGED_META.exists()):
+        return False
+    try:
+        os.replace(_STAGED_BLOB, _PROMOTED_BLOB)
+        os.replace(_STAGED_META, _PROMOTED_META)
+    except OSError as exc:
+        logger.error("Could not promote the staged project snapshot: %s", exc)
+        discard_staged()
+        return False
+    logger.info("Project snapshot promoted")
+    return True
+
+
+def discard_staged() -> None:
+    """Drop a staged snapshot after a failed build."""
+    for path in (_STAGED_BLOB, _STAGED_META):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("Could not discard the staged project snapshot: %s", exc)
+
+
+def read_metadata() -> Optional[dict]:
+    """Metadata for the stored snapshot, or None when none is stored."""
+    try:
+        record = json.loads(_PROMOTED_META.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as exc:
+        logger.warning("Stored project snapshot metadata is unreadable: %s", exc)
+        return None
+    if not isinstance(record, dict):
+        return None
+    # A metadata file without its blob describes nothing retrievable.
+    if not _PROMOTED_BLOB.exists():
+        return None
+    return record
+
+
+def read_blob() -> Optional[bytes]:
+    """Bytes of the stored snapshot, or None when none is stored."""
+    try:
+        return _PROMOTED_BLOB.read_bytes()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.error("Could not read the stored project snapshot: %s", exc)
+        return None
+
+
+def has_snapshot() -> bool:
+    return read_metadata() is not None
+
+
+def advertised_fields() -> dict:
+    """The subset of the metadata the unauthenticated discovery reply carries.
+
+    Name and timestamp only: enough for a client to populate its device picker
+    without a login per device, and nothing beyond what the picker shows.
+    Absent keys mean no stored project, so no separate flag is needed.
+    """
+    record = read_metadata()
+    if record is None:
+        return {}
+    return {
+        "project_name": record.get("projectName", ""),
+        "project_timestamp": record.get("timestamp", ""),
+    }

--- a/webserver/restapi.py
+++ b/webserver/restapi.py
@@ -258,7 +258,18 @@ def repair_missing_admin() -> bool:
 
     user = users[0]
     user.role = ADMIN_ROLE
-    db.session.commit()
+    try:
+        db.session.commit()
+    except Exception as exc:
+        # The caller runs inside a broad `except Exception: pass` that exists
+        # for the schema setup around it. Reporting here means a failed repair
+        # is not swallowed by that: it only ever gets one chance per boot, and
+        # a device that silently stayed unrepairable is the hardest version of
+        # this problem to diagnose.
+        db.session.rollback()
+        logger.error("Could not promote '%s' to administrator: %s", user.username, exc)
+        return False
+
     logger.warning(
         "Account '%s' was the only account on this device and held no "
         "administrator role, which leaves admin-only operations permanently "

--- a/webserver/restapi.py
+++ b/webserver/restapi.py
@@ -1,8 +1,9 @@
 import base64
+import json
 import os
 from typing import Callable, Optional
 
-from flask import Blueprint, Flask, jsonify, request
+from flask import Blueprint, Flask, current_app, jsonify, request
 from flask_jwt_extended import (
     JWTManager,
     create_access_token,
@@ -31,6 +32,11 @@ from webserver.retain_config import (
 from webserver.version import MIN_EDITOR_VERSION, RUNTIME_VERSION
 
 logger, buffer = get_logger("logger", use_buffer=True)
+
+# Read size for streaming the stored project out. A multiple of 3 so every chunk
+# encodes to whole base64 quads; 3 MB of source becomes 4 MB of base64, which is
+# the actual peak this bounds.
+_BASE64_CHUNK_BYTES: int = 3 * 1024 * 1024
 
 env = os.getenv("FLASK_ENV", "development")
 
@@ -970,21 +976,43 @@ def get_project_snapshot():
         return jsonify({"msg": "Admin privileges required"}), 403
 
     record = project_snapshot.read_metadata()
-    blob = project_snapshot.read_blob()
-    if record is None or blob is None:
+    if record is None or not project_snapshot.blob_path().exists():
         return jsonify({"msg": "No project is stored on this device"}), 404
 
-    return (
-        jsonify(
-            {
-                "projectName": record.get("projectName", ""),
-                "formatVersion": record.get("formatVersion"),
-                "filename": "project.zip",
-                "contentBase64": base64.b64encode(blob).decode("ascii"),
-            }
-        ),
-        200,
-    )
+    # Streamed, not assembled.
+    #
+    # The base64-in-JSON wire format is not negotiable (the agent's proxy
+    # decodes JSON or falls back to text; a binary body does not survive that
+    # trip), but building the response in memory meant holding the archive, its
+    # base64 expansion, and Flask's serialisation of the whole document at once
+    # -- roughly 3.5x the archive, which at the 100 MB cap is far more than the
+    # Pi-class hardware this targets has to spare.
+    #
+    # Encoding straight into the response bounds peak memory by the chunk size
+    # instead of the file size, and the bytes on the wire are identical. The
+    # chunk is a multiple of 3 so each one encodes to complete base64 quads with
+    # no padding until the end.
+    def stream():
+        head = {
+            "projectName": record.get("projectName", ""),
+            "formatVersion": record.get("formatVersion"),
+            "filename": "project.zip",
+        }
+        # Everything except the archive, opened for the value to be appended.
+        prefix = json.dumps(head)[:-1]
+        yield f'{prefix}, "contentBase64": "'.encode("ascii")
+        try:
+            for chunk in project_snapshot.iter_blob(_BASE64_CHUNK_BYTES):
+                yield base64.b64encode(chunk)
+        except OSError as exc:
+            # The response has already begun, so there is no status code left to
+            # change. Truncating mid-value gives the client invalid JSON, which
+            # is the honest outcome: it must not read a partial archive as whole.
+            logger.error("Streaming the stored project failed: %s", exc)
+            return
+        yield b'"}'
+
+    return current_app.response_class(stream(), mimetype="application/json")
 
 
 @restapi_bp.route("/login", methods=["POST"])

--- a/webserver/restapi.py
+++ b/webserver/restapi.py
@@ -212,6 +212,62 @@ def apply_user_schema_migrations():
         )
 
 
+def repair_missing_admin() -> bool:
+    """Rescue a device whose accounts contain no admin at all.
+
+    That state is a dead end. Once any user exists, ``create-user`` refuses a
+    caller who is not an admin and ``update-user`` refuses a role change from
+    one, so there is no sequence of API calls that produces an admin. Every
+    admin-gated operation is permanently unreachable, and nothing surfaces it
+    until someone tries one.
+
+    Devices reach it by upgrading through an early build of the roles feature,
+    whose ``role`` column was nullable with no default and whose rows landed on
+    ``user``. ``apply_user_schema_migrations`` does not help: it only runs when
+    the column is ABSENT, so a database that already has one is left alone
+    whatever is in it.
+
+    Exactly one account is promoted, because a single-user device has no
+    ambiguity about who the administrator is. With several accounts the runtime
+    has no basis for picking a winner, so it refuses to guess and says so
+    loudly instead -- that combination should barely exist in the field, since
+    multiple accounts only became possible when roles did.
+
+    Returns True when an account was promoted. Safe on every boot: a no-op the
+    moment any admin exists.
+    """
+    if admin_count() > 0:
+        return False
+
+    users = User.query.order_by(User.id).all()
+    if not users:
+        # Fresh device. The bootstrap path already makes the first account an
+        # admin, so there is nothing to repair.
+        return False
+
+    if len(users) > 1:
+        logger.error(
+            "No administrator account exists and there are %d accounts (%s). "
+            "The runtime will not choose one. Admin-only operations stay "
+            "unavailable until an administrator is restored directly in the "
+            "user database.",
+            len(users),
+            ", ".join(user.username for user in users),
+        )
+        return False
+
+    user = users[0]
+    user.role = ADMIN_ROLE
+    db.session.commit()
+    logger.warning(
+        "Account '%s' was the only account on this device and held no "
+        "administrator role, which leaves admin-only operations permanently "
+        "unreachable. Promoted it to administrator.",
+        user.username,
+    )
+    return True
+
+
 @jwt.user_identity_loader
 def user_identity_lookup(user):
     return str(user.id)

--- a/webserver/restapi.py
+++ b/webserver/restapi.py
@@ -1,3 +1,4 @@
+import base64
 import os
 from typing import Callable, Optional
 
@@ -16,6 +17,7 @@ from sqlalchemy import text as sa_text
 from werkzeug.security import check_password_hash, generate_password_hash
 
 import webserver.config
+from webserver import project_snapshot
 from webserver.logger import get_logger
 from webserver.retain_config import (
     DEFAULT_FLUSH_SECONDS,
@@ -118,6 +120,10 @@ def restapi_capabilities():
             {
                 "runtimeVersion": RUNTIME_VERSION,
                 "minEditorVersion": MIN_EDITOR_VERSION,
+                # Tells a client it may send a source-project snapshot with an
+                # upload and retrieve it later. Unauthenticated like the rest of
+                # this endpoint, so a client can decide before logging in.
+                "projectSnapshot": True,
             }
         ),
         200,
@@ -806,6 +812,112 @@ def put_retain_config():
         return jsonify({"msg": f"Could not save the settings: {e}"}), 400
 
     return jsonify(saved), 200
+
+
+@restapi_bp.route("/project-snapshot/info", methods=["GET"])
+@jwt_required()
+def get_project_snapshot_info():
+    """Describe the source project stored on this device, if any.
+
+    Authenticated but not admin-gated: this is the metadata a client needs to
+    decide whether retrieving is worth offering, and it says nothing the
+    discovery broadcast does not already hint at. The archive itself is
+    admin-only.
+    ---
+    tags:
+      - Programs
+    security:
+      - BearerAuth: []
+    responses:
+      200:
+        description: Stored project metadata, or present=false when there is none
+        schema:
+          type: object
+          properties:
+            present:
+              type: boolean
+            projectName:
+              type: string
+            editorVersion:
+              type: string
+            uploadedBy:
+              type: string
+            timestamp:
+              type: string
+            sizeBytes:
+              type: integer
+            formatVersion:
+              type: integer
+            libraries:
+              type: array
+              items:
+                type: object
+      401:
+        description: Authentication required
+    """
+    record = project_snapshot.read_metadata()
+    if record is None:
+        return jsonify({"present": False}), 200
+    return jsonify({"present": True, **record}), 200
+
+
+@restapi_bp.route("/project-snapshot", methods=["GET"])
+@jwt_required()
+def get_project_snapshot():
+    """Retrieve the stored source project as a base64 ZIP.
+
+    Admin only. The stored project is NOT encrypted on the device -- anyone
+    with filesystem access can read it -- so this role check is the whole of
+    the access control, not a second layer behind one.
+
+    Base64 inside JSON rather than a binary body on purpose: openplc-web
+    reaches devices through the orchestrator agent's HTTP proxy, which decodes
+    responses as JSON or falls back to text. A binary body does not survive
+    that trip.
+    ---
+    tags:
+      - Programs
+    security:
+      - BearerAuth: []
+    responses:
+      200:
+        description: The stored project archive
+        schema:
+          type: object
+          properties:
+            projectName:
+              type: string
+            filename:
+              type: string
+            contentBase64:
+              type: string
+              description: The project ZIP, base64-encoded
+      401:
+        description: Authentication required
+      403:
+        description: Admin privileges required
+      404:
+        description: No project is stored on this device
+    """
+    if not (current_user and current_user.is_admin()):
+        return jsonify({"msg": "Admin privileges required"}), 403
+
+    record = project_snapshot.read_metadata()
+    blob = project_snapshot.read_blob()
+    if record is None or blob is None:
+        return jsonify({"msg": "No project is stored on this device"}), 404
+
+    return (
+        jsonify(
+            {
+                "projectName": record.get("projectName", ""),
+                "formatVersion": record.get("formatVersion"),
+                "filename": "project.zip",
+                "contentBase64": base64.b64encode(blob).decode("ascii"),
+            }
+        ),
+        200,
+    )
 
 
 @restapi_bp.route("/login", methods=["POST"])


### PR DESCRIPTION
Integration PR for the runtime's half of **Retrieve Project from PLC** (epic RTOP-272). Each child task was reviewed and merged into this branch individually; this is the branch going to `development`.

**This is the repo the other three depend on.** The editor and web clients are useless against a runtime without these endpoints, so this should land first.

A device now keeps a copy of the source project it is running, so the project can be opened again from a machine that does not have it — the case where an engineer left, a laptop died, or a panel has been running for two years and nobody knows which version is in it.

## Child PRs already merged here

| PR | Ticket | What |
| --- | --- | --- |
| #180 | RTOP-273 | Snapshot storage, the upload field, and the retrieval endpoints |
| #181 | RTOP-278 | Rescue a device whose accounts contain no administrator |
| #182 | RTOP-277 | Documentation, security first |

## What reviewers should look at

**The runtime never parses the archive.** It is an opaque blob; metadata arrives in separate form fields and is normalised into a record the device owns (unknown keys dropped, since everything there is echoed back to other clients). 100 MB cap.

**The lifecycle is the subtle part.** Three rules keep a device from ever advertising a project it is not running:

- The stored project is cleared at the upload's *point of no return*, not on arrival — so a rejected upload (bad zip, too large, runtime busy) leaves the previous program **and** its project untouched, which is the pair that is still true.
- The new project is staged only *after* `safe_extract` succeeds, and promoted or discarded in `run_compile`'s `finally`. Staging before the extract could strand a snapshot that the *next* successful build would then promote — belonging to an upload that never landed. That was a self-review catch and has a regression test.
- An upload carrying no project erases the stored one. Deliberate: `openplc-cli`, older editors and third-party clients upload without one, and a surviving project would describe a program that is gone.

**The discovery reply gained two fields**, `project_name` and `project_timestamp`, **absent rather than empty** when nothing is stored — which is what lets a client distinguish "nothing stored" from "stored but unnamed" without a separate flag. Note this reply is unauthenticated, so the project *name* is readable by anything on the network; the archive is not.

**Access control is one role check, and the docs say so plainly.** `GET /api/project-snapshot` is admin-only; `/info` is authenticated but not admin-gated, since it says nothing discovery does not already carry. The stored project is **not encrypted** and there is **no integrity guarantee** — `docs/RETRIEVE_PROJECT.md` and a new section in `docs/SECURITY.md` state this directly rather than softening it.

**The admin repair (#181)** exists because retrieval needs an administrator and nothing else did, so a device with no admin account was previously unnoticeable. A *sole* non-admin account is promoted at startup — it is already that device's whole administration. Several non-admin accounts are deliberately left alone: picking one would invent an authority the deployment never granted.

## Testing

65 tests across the snapshot, admin-repair, capabilities and discovery suites, all passing. Exercised end-to-end on real hardware via `openplc-cli`: upload with a project, retrieve it back, failed-compile discards, CLI upload clears.

**Pre-existing suite failures, not from this branch:** 14 failures (`test_vpp_anchor_cross_language.py`, `test_openplc_input_registers_datablock.py`) and 3 collection errors in the OPC-UA plugin tests (`pytest_asyncio` not installed in the test venv). All reproduce identically on `development` — verified by checking out `development` and running the same files.

## Cross-repo

- **openplc-editor** #1070 — the desktop client
- **openplc-web** #720 — the web client
- **orchestrator-agent** #125 (RTOP-281) — the discovery scan web needs for project names
- **RTOP-282** — the Edge relay endpoint, not started; until it ships the web picker lists devices without project names, behind a capability check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpea15BYCgPSqpatpveRk1