### PR TITLE
fix(api): remove /project-snapshot/info, which no client calls

### DIFF
--- a/docs/RETRIEVE_PROJECT.md
+++ b/docs/RETRIEVE_PROJECT.md
@@ -97,10 +97,10 @@ The flow is the same on both clients: **File -> Retrieve Project from PLC**.
    Picking the device you are already signed in to reuses that session and skips
    straight to the retrieval.
 
-3. **Sign in as an administrator.** Any authenticated user can see *that* a
-   project is stored and what it is called; only an administrator can retrieve
-   the archive itself. A non-administrator who performed the upload still cannot
-   retrieve it.
+3. **Sign in as an administrator.** Anything on the network can see *that* a
+   project is stored and what it is called, because the discovery reply is
+   unauthenticated; only an administrator can retrieve the archive itself. A
+   non-administrator who performed the upload still cannot retrieve it.
 
 4. **The project opens.** It is unpacked into a scratch directory and opened as
    an ordinary project.
@@ -131,29 +131,15 @@ opening it in the desktop editor.
 
 ## HTTP API
 
-Both endpoints require authentication. See [API.md](API.md) for the
+The retrieval endpoint requires authentication. See [API.md](API.md) for the
 authentication flow.
 
-### `GET /api/project-snapshot/info`
-
-What is stored, without the archive. Authenticated, but not restricted to
-administrators: this is what a client needs to decide whether retrieving is
-worth offering, and it says nothing the discovery reply does not already carry.
-
-```json
-{
-  "present": true,
-  "projectName": "Traffic Light",
-  "editorVersion": "1.2.0",
-  "uploadedBy": "operator",
-  "timestamp": "2026-08-31T12:00:00Z",
-  "sizeBytes": 48213,
-  "formatVersion": 1,
-  "libraries": [{ "name": "oscat-basic", "version": "3.3.4", "hash": "9f2c..." }]
-}
-```
-
-When the device stores nothing: `{"present": false}`.
+What a device is storing is published two ways: its name and timestamp in the
+unauthenticated discovery reply, which is what fills a client's device picker,
+and the archive itself here. There is deliberately no authenticated
+"describe it without fetching it" endpoint -- one existed briefly and had no
+caller, because a picker has to describe a device *before* anyone signs in to
+it, which an authenticated endpoint cannot do.
 
 ### `GET /api/project-snapshot`
 

--- a/tests/pytest/restapi/test_project_snapshot.py
+++ b/tests/pytest/restapi/test_project_snapshot.py
@@ -214,39 +214,6 @@ def test_discovery_advertises_only_name_and_timestamp():
     }
 
 
-# --- GET /api/project-snapshot/info --------------------------------------
-
-
-def test_info_requires_authentication(client):
-    assert client.get("/api/project-snapshot/info").status_code == 401
-
-
-def test_info_reports_absence_on_a_fresh_device(client, admin_token):
-    body = client.get("/api/project-snapshot/info", headers=auth(admin_token)).get_json()
-    assert body == {"present": False}
-
-
-def test_info_reports_the_stored_project(client, admin_token):
-    _store(b"payload")
-    body = client.get("/api/project-snapshot/info", headers=auth(admin_token)).get_json()
-    assert body["present"] is True
-    assert body["projectName"] == "Traffic Light"
-    assert body["editorVersion"] == "4.2.0"
-    assert body["uploadedBy"] == "admin"
-    assert body["sizeBytes"] == len(b"payload")
-    assert body["libraries"][0]["name"] == "Motion"
-
-
-def test_info_is_open_to_non_admins(client, admin_token):
-    # Deciding whether to OFFER retrieval is not privileged; retrieving is.
-    _store()
-    create_user(client, "operator", "operator-pass", token=admin_token, role="user")
-    operator = token_for(client, "operator", "operator-pass")
-    resp = client.get("/api/project-snapshot/info", headers=auth(operator))
-    assert resp.status_code == 200
-    assert resp.get_json()["present"] is True
-
-
 # --- GET /api/project-snapshot -------------------------------------------
 
 

--- a/webserver/restapi.py
+++ b/webserver/restapi.py
@@ -811,53 +811,6 @@ def put_retain_config():
     return jsonify(saved), 200
 
 
-@restapi_bp.route("/project-snapshot/info", methods=["GET"])
-@jwt_required()
-def get_project_snapshot_info():
-    """Describe the source project stored on this device, if any.
-
-    Authenticated but not admin-gated: this is the metadata a client needs to
-    decide whether retrieving is worth offering, and it says nothing the
-    discovery broadcast does not already hint at. The archive itself is
-    admin-only.
-    ---
-    tags:
-      - Programs
-    security:
-      - BearerAuth: []
-    responses:
-      200:
-        description: Stored project metadata, or present=false when there is none
-        schema:
-          type: object
-          properties:
-            present:
-              type: boolean
-            projectName:
-              type: string
-            editorVersion:
-              type: string
-            uploadedBy:
-              type: string
-            timestamp:
-              type: string
-            sizeBytes:
-              type: integer
-            formatVersion:
-              type: integer
-            libraries:
-              type: array
-              items:
-                type: object
-      401:
-        description: Authentication required
-    """
-    record = project_snapshot.read_metadata()
-    if record is None:
-        return jsonify({"present": False}), 200
-    return jsonify({"present": True, **record}), 200
-
-
 @restapi_bp.route("/project-snapshot", methods=["GET"])
 @jwt_required()
 def get_project_snapshot():


### PR DESCRIPTION
Paired cleanup for the client-side removal in openplc-editor#1072. Raised because leaving only one half done is how an endpoint outlives the reason it existed — the reviewer's point on that PR was that removing the client without the server leaves the runtime serving something nothing asks for, and that the decision belongs somewhere more durable than a PR body.

## Why it goes rather than gets a caller

The endpoint is authenticated, so it can only answer about a device you have **already signed in to**. The one thing a client wants "what is this device storing?" for is filling the retrieve picker — which has to describe devices *before* anyone signs in to any of them. So the shape of the endpoint rules out the only use it had.

That job is already done, unauthenticated, by the UDP discovery reply's `project_name` and `project_timestamp`. The authenticated path that remains, `GET /api/project-snapshot`, hands back the archive itself, admin-only.

Verified nothing calls it — `project-snapshot/info` returns no hits in `openplc-editor`, `openplc-web` or `orchestrator-agent`.

## Scope

- `webserver/restapi.py` — the route and handler (−47)
- `tests/pytest/restapi/test_project_snapshot.py` — its four tests (−33)
- `docs/RETRIEVE_PROJECT.md` — the section, plus two corrections below

## Docs got more than a deletion

The API section said *"Both endpoints require authentication"* and described this one. Rather than trimming it to silence, it now explains the two ways a stored project is published and **why there is deliberately no describe-without-fetching endpoint** — so the next person reaching for one finds the reasoning instead of re-adding it.

One neighbouring claim was also wrong and is fixed: *"Any authenticated user can see that a project is stored and what it is called"* was true of this endpoint, but the discovery reply is unauthenticated — so **anything on the network** can see that. Worth stating correctly in a document whose whole point is not overselling this feature's security.

## Testing

187 pytest pass. Pre-existing failures excluded and unchanged (identical on `development`): 14 in `test_vpp_anchor_cross_language.py` / `test_openplc_input_registers_datablock.py`, plus 3 OPC-UA collection errors from `pytest_asyncio` missing in the test venv.

Note this is technically a public API removal, like #185. Nothing first-party calls it and it shipped only in `development` (never in a release), so the exposure is smaller — but it is worth the same release-note line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpea15BYCgPSqpatpveRk1