### PR TITLE
Fix OPC UA DT conversion from nanoseconds

### DIFF
--- a/core/src/drivers/plugins/python/opcua/opcua_utils.py
+++ b/core/src/drivers/plugins/python/opcua/opcua_utils.py
@@ -222,12 +222,21 @@ def convert_value_for_opcua(datatype: str, value: Any) -> Any:
                 tv_sec, tv_nsec = value
                 try:
                     dt = datetime.fromtimestamp(tv_sec, tz=timezone.utc)
-                    dt = dt.replace(microsecond=tv_nsec // 1000)
-                    return dt
+                    return dt.replace(microsecond=tv_nsec // 1000)
                 except (OSError, OverflowError, ValueError):
                     return datetime(1970, 1, 1, tzinfo=timezone.utc)
             elif isinstance(value, datetime):
                 return value
+            elif isinstance(value, int):
+                # Some OpenPLC debug interfaces expose DT as Unix time
+                # in nanoseconds instead of an IEC_TIMESPEC tuple.
+                try:
+                    return datetime.fromtimestamp(
+                        value / 1_000_000_000,
+                        tz=timezone.utc
+                    )
+                except (OSError, OverflowError, ValueError):
+                    return datetime(1970, 1, 1, tzinfo=timezone.utc)
             return datetime(1970, 1, 1, tzinfo=timezone.utc)
 
         else:


### PR DESCRIPTION
## Description

Fixes an issue where OPC UA `DT` values could be converted to
`1970-01-01` instead of the actual DateTime.

## Problem

When the OPC UA synchronization layer receives a `DT` value as an
integer Unix timestamp expressed in nanoseconds, the existing
conversion logic did not handle this representation.

As a result, the conversion fell back to:

`1970-01-01 00:00:00+00:00`

## Root Cause

The `DT` conversion handled:

- `(tv_sec, tv_nsec)` tuples
- Python `datetime` objects

but did not handle integer nanosecond timestamps returned by some
OpenPLC debug interfaces.

## Fix

Added support for integer Unix timestamps expressed in nanoseconds:

```python
datetime.fromtimestamp(
    value / 1_000_000_000,
    tz=timezone.utc
)